### PR TITLE
add mecha-ja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ tmp/
 # verbose output
 *verbose.jsonl
 __depr__/
+
+# examples/llava for evaluating LLM-jp-3 VILA
+examples/llava/*

--- a/eval_all.sh
+++ b/eval_all.sh
@@ -35,6 +35,8 @@ declare -a task_list=(
     "jdocqa"
     "mmmu"
     "llava-bench-in-the-wild"
+    "jic-vqa"
+    "mecha-ja"
 )
 
 # Define metrics per task
@@ -47,6 +49,8 @@ declare -A METRIC_MAP=(
     ["jdocqa"]="jdocqa,llm_as_a_judge"
     ["mmmu"]="mmmu"
     ["llava-bench-in-the-wild"]="llm_as_a_judge,rougel"
+    ["jic-vqa"]="jic-vqa"
+    ["mecha-ja"]="mecha-ja"
 )
 
 # Result directories

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -44,6 +44,7 @@ valid_metrics = [
     "llm_as_a_judge",
     "mmmu",
     "jic_vqa",
+    "mecha-ja",
 ]
 
 

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -33,6 +33,11 @@ parser.add_argument(
     default="llm_as_a_judge_heron_bench",
     help="metrics to evaluate. You can specify multiple metrics separated by comma (e.g. --metrics exact_match,llm_as_a_judge) You can use rougel,substring_match,jmmmu,jdocqa,llm_as_a_judge_heron_bench,exact_match",
 )
+parser.add_argument(
+    "--rotate_choices",
+    action="store_true",
+    help="If set, rotate the choices of MCQ options for evaluation.",
+)
 
 valid_metrics = [
     "rougel",
@@ -73,6 +78,7 @@ task_config = eval_mm.api.task.TaskConfig(
     max_dataset_len=args.max_dataset_len,
     judge_model=args.judge_model,
     batch_size_for_evaluation=args.batch_size_for_evaluation,
+    rotate_choices=args.rotate_choices,
 )
 task = eval_mm.api.registry.get_task_cls(task_id)(task_config)
 
@@ -145,12 +151,18 @@ for metric in metrics:
     print(f"{metric}: {calculated_metrics[metric]}")
 
 
-with open(os.path.join(prediction_result_file_path), "w") as f:
+with open(prediction_result_file_path, "w") as f:
     for i, pred in enumerate(preds):
         question_id = pred["question_id"]
         text = pred["text"]
         answer = task.doc_to_answer(task.dataset[i])
-        content = {"question_id": question_id, "text": text, "answer": answer}
+        input_text = task.doc_to_text(task.dataset[i])
+        content = {
+            "question_id": question_id,
+            "text": text,
+            "answer": answer,
+            "input_text": input_text,
+        }
         for metric in metrics:
             content[metric] = scores_for_each_metric[metric][i]
         f.write(json.dumps(content, ensure_ascii=False) + "\n")
@@ -160,5 +172,5 @@ eval_result_file_path = os.path.join(
     evaluation_result_dir, f"{args.model_id.replace('/', '-')}.json"
 )
 with open(eval_result_file_path, "w") as f:
-    f.write(json.dumps(calculated_metrics, ensure_ascii=False) + "\n")
+    json.dump(calculated_metrics, ensure_ascii=False, indent=4, fp=f)
 print(f"Evaluation result saved to {eval_result_file_path}")

--- a/scripts/consistency_mecha_ja.py
+++ b/scripts/consistency_mecha_ja.py
@@ -1,0 +1,187 @@
+import os
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+import japanize_matplotlib
+import numpy as np
+
+# ======================================
+# モデルごとのjsonlファイルパスを設定
+# ======================================
+vis_dir = "logs/mecha-ja/visualize/"
+root_dir = "logs/mecha-ja/prediction/"
+files = os.listdir(root_dir)
+model_names = [
+    os.path.basename(f).replace(".jsonl", "") for f in files if f.endswith(".jsonl")
+]
+
+model_files = {
+    model_name: os.path.join(root_dir, f"{model_name}.jsonl")
+    for model_name in model_names
+}
+
+model_dfs = {}
+
+
+# ======================================
+# JSONLを読み込み、DataFrame化する関数
+# ======================================
+def load_jsonl_to_df(file_path):
+    data_list = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line in f:
+            data_list.append(json.loads(line.strip()))
+    return pd.DataFrame(data_list)
+
+
+# ======================================
+# データ読み込み & 予測列の追加
+# ======================================
+def check_abcd(text):
+    letters = ["A", "B", "C", "D"]
+    found = [
+        ch for ch in letters if ch in text
+    ]  # テキスト中に含まれる A/B/C/D をリスト化
+    # 含まれている文字がちょうど1つならその文字、そうでなければ F を返す
+    return found[0] if len(found) == 1 else "F"
+
+
+for model_name, file_path in model_files.items():
+    df = load_jsonl_to_df(file_path)
+    df["pred"] = df["text"].apply(check_abcd)
+    model_dfs[model_name] = df
+
+rotate_map = {
+    "A": ["A", "D", "C", "B"],
+    "B": ["B", "A", "D", "C"],
+    "C": ["C", "B", "A", "D"],
+    "D": ["D", "C", "B", "A"],
+}
+
+# ======================================
+# (1) モデルごとの回答選択肢の分布を可視化（相対頻度）
+# ======================================
+# 3 x 3 のグリッドで可視化
+fig, axes = plt.subplots(nrows=3, ncols=3, figsize=(10, 10), sharex=True, sharey=True)
+
+# axesを1次元にする
+axes = axes.flatten()
+
+for ax, (model_name, df) in zip(axes, model_dfs.items()):
+    # 予測回答の分布（相対頻度）をカウント
+    pred_counts = (
+        df["pred"].value_counts().reindex(["A", "B", "C", "D", "F"], fill_value=0)
+    )
+    pred_counts = pred_counts / pred_counts.sum()  # 相対頻度に変換
+
+    ax.bar(
+        pred_counts.index,
+        pred_counts.values,
+        color=["#FF9999", "#FFE888", "#99FF99", "#99CCFF", "#CCCCCC"],
+    )
+
+    # 0.25 に赤い線を引く
+    ax.axhline(y=0.25, color="r", linestyle="--", linewidth=1)
+
+    ax.set_title(f"{model_name}")
+    ax.set_xlabel("選択肢")
+    ax.set_ylabel("選択頻度")
+
+plt.tight_layout()
+plt.savefig(os.path.join(vis_dir, "prediction_distribution.png"))
+plt.close()
+
+# ======================================
+# (2) soft accuracy, strict accuracy, consistency の計算
+# --------------------------------------
+# ・soft accuracy: 単純に df["mecha-ja"] の平均値
+# ・strict accuracy: 同じ問題 (q_base) で全て mecha-ja==1 なら正解とカウント
+# ・consistency: rot0 の予測に応じて rotate_map 通りになっている割合
+# ======================================
+results = []
+
+for model_name, df in model_dfs.items():
+    # soft accuracy
+    soft_accuracy = df["mecha-ja"].mean()  # 1と0の平均 = 正解率
+
+    # "X_rotY" の "X" 部分を q_base として抽出
+    df["q_base"] = df["question_id"].apply(lambda x: x.split("_rot")[0])
+    # 回転番号を取得
+    df["rot"] = df["question_id"].apply(lambda x: int(x.split("_rot")[1]))
+
+    grouped = df.groupby("q_base")
+    unique_questions = df["q_base"].unique()
+
+    correct_count = 0  # strict用
+    consistent_count = 0
+
+    for q_id, group in grouped:
+        # strict正答率 (全rotで mecha-ja == 1)
+        if all(group["mecha-ja"] == 1):
+            correct_count += 1
+
+        # 一貫性 (rotate_map に従っているか)
+        group_sorted = group.sort_values("rot")
+        preds = group_sorted["pred"].tolist()  # rot0→rot1→rot2→rot3 の順
+
+        pred_rot0 = preds[0]  # 最初が rot0
+        if pred_rot0 in rotate_map:
+            expected_sequence = rotate_map[pred_rot0]
+            # 一貫しているかどうか
+            if len(preds) == 4 and preds == expected_sequence:
+                consistent_count += 1
+
+    strict_accuracy = (
+        correct_count / len(unique_questions) if len(unique_questions) else 0
+    )
+    consistency = (
+        consistent_count / len(unique_questions) if len(unique_questions) else 0
+    )
+
+    results.append(
+        {
+            "model": model_name,
+            "soft_accuracy": soft_accuracy,
+            "strict_accuracy": strict_accuracy,
+            "consistency": consistency,
+        }
+    )
+
+results_df = pd.DataFrame(results)
+print(results_df)
+
+# ======================================
+# (3) 3種の指標 (soft, strict, consistency) を棒グラフで比較
+# ======================================
+metrics = ["soft_accuracy", "strict_accuracy", "consistency"]
+x = np.arange(len(results_df))  # モデル数
+width = 0.25  # 棒の幅
+
+fig, ax = plt.subplots(figsize=(8, 8))
+
+ax.bar(x, results_df["soft_accuracy"], width=width, label="Soft Accuracy", alpha=0.7)
+ax.bar(
+    x - width,
+    results_df["strict_accuracy"],
+    width=width,
+    label="Strict Accuracy",
+    alpha=0.7,
+)
+ax.bar(
+    x + width + 0.05,
+    results_df["consistency"],
+    width=width,
+    label="Consistency",
+    alpha=0.7,
+)
+
+ax.set_xticks(x)
+ax.set_xticklabels(results_df["model"], rotation=90)
+ax.set_ylim(0, 1)
+ax.set_ylabel("Rate")
+ax.set_title("Soft/Strict Accuracy & Consistency by Model")
+ax.legend()
+
+plt.tight_layout()
+plt.savefig(os.path.join(vis_dir, "accuracy_consistency_comparison.png"))
+plt.close()

--- a/src/eval_mm/api/task.py
+++ b/src/eval_mm/api/task.py
@@ -10,6 +10,7 @@ class TaskConfig:
     max_dataset_len: int | None = None
     judge_model: str = "gpt-4o-mini-2024-07-18"
     batch_size_for_evaluation: int = 10
+    rotate_choices: bool = False
 
 
 class Task(abc.ABC):

--- a/src/eval_mm/metrics/__init__.py
+++ b/src/eval_mm/metrics/__init__.py
@@ -8,7 +8,7 @@ from .jmmmu_scorer import JMMMUScorer
 from .mmmu_scorer import MMMUScorer
 from .jdocqa_scorer import JDocQAScorer
 from .jic_vqa_scorer import JICVQAScorer
-
+from .mecha_ja_scorer import MECHAJaScorer
 
 class ScorerRegistry:
     """Registry to map metrics to their corresponding scorer classes."""

--- a/src/eval_mm/metrics/mecha_ja_scorer.py
+++ b/src/eval_mm/metrics/mecha_ja_scorer.py
@@ -1,0 +1,119 @@
+# mecha-ja-scorer.py
+from .scorer import Scorer
+import re
+from collections import defaultdict
+
+ANSWER_TYPE_MAP = {
+    "Factoid": 0,
+    "Non-Factoid": 1,
+}
+
+
+class MECHAJaScorer(Scorer):
+    @staticmethod
+    def _parse_rotation_id(qid: str) -> str:
+        """
+        question_id に '_rot{i}' が含まれているかを正規表現で調べる。
+        含まれていれば i (数字) を文字列として返し、無ければ "no_rot" を返す。
+        """
+        pattern = r"(.*)_rot(\d+)$"
+        match = re.match(pattern, qid)
+        if match:
+            return match.group(2)  # 例えば "2"
+        else:
+            return "no_rot"
+
+    @staticmethod
+    def score(refs: list[str], preds: list[str], **kwargs) -> list[int]:
+        """
+        Checks whether each reference string is contained in the corresponding
+        prediction string and returns a list of integer scores (1 for True, 0 for False).
+        """
+        scores = []
+        for ref, pred in zip(refs, preds):
+            score = 1 if ref in pred else 0
+            scores.append(score)
+        return scores
+
+    @staticmethod
+    def aggregate(scores: list[int], docs: list[dict], **kwargs) -> dict:
+        """
+        回転IDごとにスコアを集計して、以下のような構造を返す:
+        {
+          "rot_{rot_id}": {
+            "overall": float,
+            "Factoid": float,
+            "Non-Factoid": float,
+            "with_background": float,
+            "without_background": float
+          },
+          "no_rot": { ... },
+          ...
+        }
+        """
+
+        # data_by_rot[rot_id] = {
+        #   "overall": [],
+        #   "factoid": [],
+        #   "non_factoid": [],
+        #   "with_bg": [],
+        #   "without_bg": []
+        # }
+
+        data_all = defaultdict(list)
+        data_by_rot = defaultdict(
+            lambda: {
+                "overall": [],
+                "factoid": [],
+                "non_factoid": [],
+                "with_bg": [],
+                "without_bg": [],
+            }
+        )
+
+        for doc, score in zip(docs, scores):
+            rot_id = MECHAJaScorer._parse_rotation_id(doc["question_id"])
+            is_factoid = doc["answer_type"] == ANSWER_TYPE_MAP["Factoid"]
+            has_bg = bool(doc["background_text"])
+
+            # Overall
+            data_all["overall"].append(score)
+            data_by_rot[rot_id]["overall"].append(score)
+
+            # Factoid / Non-Factoid
+            if is_factoid:
+                data_all["factoid"].append(score)
+                data_by_rot[rot_id]["factoid"].append(score)
+            else:
+                data_all["non_factoid"].append(score)
+                data_by_rot[rot_id]["non_factoid"].append(score)
+
+            # With / Without Background
+            if has_bg:
+                data_all["with_bg"].append(score)
+                data_by_rot[rot_id]["with_bg"].append(score)
+            else:
+                data_all["without_bg"].append(score)
+                data_by_rot[rot_id]["without_bg"].append(score)
+
+        def avg(lst):
+            return sum(lst) / len(lst) if lst else 0.0
+
+        result = {
+            "overall": avg(data_all["overall"]),
+            "Factoid": avg(data_all["factoid"]),
+            "Non-Factoid": avg(data_all["non_factoid"]),
+            "with_background": avg(data_all["with_bg"]),
+            "without_background": avg(data_all["without_bg"]),
+        }
+
+        for rot_id, cat_scores in data_by_rot.items():
+            result[f"rot_{rot_id}"] = {
+                "overall": avg(cat_scores["overall"]),
+                "Factoid": avg(cat_scores["factoid"]),
+                "Non-Factoid": avg(cat_scores["non_factoid"]),
+                "with_background": avg(cat_scores["with_bg"]),
+                "without_background": avg(cat_scores["without_bg"]),
+            }
+
+        return result

--- a/src/eval_mm/tasks/__init__.py
+++ b/src/eval_mm/tasks/__init__.py
@@ -7,3 +7,4 @@ from .jdocqa import JDocQA
 from .mmmu import MMMU
 from .llava_bench_in_the_wild import LlavaBenchIntheWild
 from .jic_vqa import JICVQA
+from .mecha_ja import MECHAJa

--- a/src/eval_mm/tasks/mecha_ja.py
+++ b/src/eval_mm/tasks/mecha_ja.py
@@ -1,0 +1,172 @@
+from datasets import Dataset, load_dataset
+from ..api.registry import register_task
+from ..api.task import Task
+from eval_mm.metrics import ScorerRegistry
+
+MULTI_CHOICE_PROMPT = (
+    "与えられた選択肢の中から最も適切な回答のアルファベットを直接記入してください。"
+)
+
+OPTIONS_MAP = {
+    0: "A",
+    1: "B",
+    2: "C",
+    3: "D",
+}
+
+
+def parse_options(options):
+    option_letters = [chr(ord("A") + i) for i in range(len(options))]
+    choices_str = "\n".join(
+        [
+            f"{option_letter}. {option}"
+            for option_letter, option in zip(option_letters, options)
+        ]
+    )
+    return choices_str
+
+
+def construct_prompt(question, options):
+    parsed_options = parse_options(options)
+    return f"{question}\n{parsed_options}\n\n{MULTI_CHOICE_PROMPT}"
+
+
+def rotate_single_example(doc):
+    """
+    1つの doc に対して4パターン (options を左回転0,1,2,3) を作り、
+    その際に answer も回転にあわせて更新し、各パターンの辞書をリストで返す。
+    """
+    base_opts = doc["options"]
+    n = len(base_opts)  # 4想定
+    orig_answer_idx = doc["answer"]  # 0~3
+    results = []
+    for i in range(n):
+        rotated_options = base_opts[i:] + base_opts[:i]
+        new_answer_idx = (orig_answer_idx - i) % n
+        new_doc = dict(doc)
+        new_doc["options"] = rotated_options
+        new_doc["answer"] = new_answer_idx
+        new_doc["answer_text"] = OPTIONS_MAP[new_answer_idx]
+        new_doc["question_id"] = f"{doc['question_id']}_rot{i}"
+        new_doc["input_text"] = construct_prompt(
+            new_doc["question"], new_doc["options"]
+        )
+        results.append(new_doc)
+    return results
+
+
+def rotate_options_fn(batch):
+    """
+    batched=True 用の関数。
+    batch: dict of lists
+    これを1つずつ取り出して rotate_single_example で4つに拡張し、
+    最終的に「列ごとのリスト」を返す。
+    """
+    # 出力用の空リストを用意
+    new_batch = {
+        "question": [],
+        "options": [],
+        "answer": [],
+        "answer_text": [],
+        "image": [],
+        "question_id": [],
+        "answer_type": [],
+        "background_text": [],
+        "input_text": [],
+    }
+
+    num_examples = len(batch["question_id"])
+    for i in range(num_examples):
+        # i番目のサンプル doc をまとめる
+        doc = {
+            "question": batch["question"][i],
+            "options": batch["options"][i],
+            "answer": batch["answer"][i],
+            "answer_type": batch["answer_type"][i],
+            "image": batch["image"][i],
+            "background_text": batch["background_text"][i],
+            "question_id": batch["question_id"][i],
+        }
+        # rotateして複数サンプルに展開
+        rotated_docs = rotate_single_example(doc)
+        # new_batch にappend
+        for rd in rotated_docs:
+            new_batch["question"].append(rd["question"])
+            new_batch["options"].append(rd["options"])
+            new_batch["answer"].append(rd["answer"])
+            new_batch["answer_text"].append(rd["answer_text"])
+            new_batch["image"].append(rd["image"])
+            new_batch["question_id"].append(rd["question_id"])
+            new_batch["answer_type"].append(rd["answer_type"])
+            new_batch["background_text"].append(rd["background_text"])
+            new_batch["input_text"].append(rd["input_text"])
+
+    return new_batch
+
+
+@register_task("mecha-ja")
+class MECHAJa(Task):
+    def __init__(self, config):
+        super().__init__(config)
+
+        ds = self._prepare_dataset()
+
+        # rotate_choices が有効なら4パターン展開
+        if getattr(self.config, "rotate_choices", False):
+            ds = ds.map(
+                rotate_options_fn,
+                batched=True,
+                remove_columns=ds.column_names,
+            )
+        self.dataset = ds
+
+    @staticmethod
+    def _prepare_dataset() -> Dataset:
+        ds = load_dataset("llm-jp/MECHA-ja", split="test")
+
+        ds = ds.map(
+            lambda x, idx: {
+                "question": x["question"],
+                "options": x["options"],
+                "answer": x["answer"],  # 0~3
+                "answer_type": x["answer_type"],
+                "image": x["image"],
+                "background_text": x["background_text"],
+                "question_id": str(idx),
+                "answer_text": OPTIONS_MAP[x["answer"]],
+                "input_text": construct_prompt(x["question"], x["options"]),
+            },
+            with_indices=True,
+        )
+
+        return ds
+
+    @staticmethod
+    def doc_to_text(doc):
+        return doc["input_text"]
+
+    @staticmethod
+    def doc_to_visual(doc):
+        return doc["image"]
+
+    @staticmethod
+    def doc_to_id(doc):
+        return doc["question_id"]
+
+    @staticmethod
+    def doc_to_answer(doc):
+        return doc["answer_text"]
+
+    def calc_scores(self, preds: list, metric: str) -> list:
+        scorer = ScorerRegistry.get_scorer(metric)
+        refs = [doc["answer_text"] for doc in self.dataset]
+        pred_texts = [p["text"] for p in preds]
+        kwargs = {
+            "docs": self.dataset,
+            "batch_size": self.config.batch_size_for_evaluation,
+        }
+        return scorer.score(refs, pred_texts, **kwargs)
+
+    def gather_scores(self, scores: list[dict], metric: str) -> dict:
+        scorer = ScorerRegistry.get_scorer(metric)
+        return scorer.aggregate(scores, docs=self.dataset)


### PR DESCRIPTION
以下の研究報告に基づいたベンチマークMECHA-jaを統合したいです．`eval_all.sh`できるか確認をお願いします．

```text
前田航希, 長谷川騎平, 栗田修平, 小田悠介, 徳久良子, and 岡崎直観. 日本の文化常識・日常生活知識理解のための視覚言語ベンチマーク MECHA-Ja の構築. In 情報処理学会 第263回自然言語処理研究会 研究報告 (2024-NL-263), number 28, pages 1–7, March 2025.
```