### PR TITLE
Generalize aggregate() output type and Remove unnecessary methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ This tool automatically evaluates Japanese multi-modal large language models acr
 
 ![What llm-jp-eval-mm provides](https://github.com/llm-jp/llm-jp-eval-mm/blob/master/assets/teaser.png)
 
-For details on the data format and the list of supported data, please check [DATASET.md](./DATASET.md).
-
 ## Table of Contents
 
 - [llm-jp-eval-mm](#llm-jp-eval-mm)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,19 @@ If you want to evaluate multiple models on multiple tasks, please check `eval_al
 
 ### Leaderboard
 
-Leaderboard is [here](https://llm-jp.github.io/llm-jp-eval-mm/)
+You can create a leaderboard.md file by running the following command:
+```bash
+python scripts/make_leaderboard.py --result_dir result
+```
+
+Table like below will be created in `leaderboard.md` file.
+| Model                    | Heron/LLM | JVB-ItW/LLM | JVB-ItW/Rouge |
+| :----------------------- | --------: | ----------: | ------------: |
+| llava-hf/llava-1.5-7b-hf |   36.9038 |         2.7 |       40.7525 |
+
+
+
+Official Leaderboard is [here](https://llm-jp.github.io/llm-jp-eval-mm/)
 
 ## Supported Tasks
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Japanese Task:
 - [JDocQA](https://github.com/mizuumi/JDocQA)
 - [JMMMU](https://huggingface.co/datasets/JMMMU/JMMMU)
 - [JIC-VQA](https://huggingface.co/datasets/line-corporation/JIC-VQA)
+- [MECHA-ja](https://huggingface.co/datasets/llm-jp/MECHA-ja)
 
 English Task:
 - [MMMU](https://huggingface.co/datasets/MMMU/MMMU)

--- a/eval_all.sh
+++ b/eval_all.sh
@@ -43,21 +43,21 @@ declare -a task_list=(
 
 # Define metrics per task
 declare -A METRIC_MAP=(
-    ["japanese-heron-bench"]="llm_as_a_judge_heron_bench"
-    ["ja-vlm-bench-in-the-wild"]="llm_as_a_judge,rougel"
-    ["ja-vg-vqa-500"]="llm_as_a_judge,rougel"
+    ["japanese-heron-bench"]="heron-bench"
+    ["ja-vlm-bench-in-the-wild"]="llm-as-a-judge,rougel"
+    ["ja-vg-vqa-500"]="llm-as-a-judge,rougel"
     ["jmmmu"]="jmmmu"
-    ["ja-multi-image-vqa"]="llm_as_a_judge,rougel"
-    ["jdocqa"]="jdocqa,llm_as_a_judge"
+    ["ja-multi-image-vqa"]="llm-as-a-judge,rougel"
+    ["jdocqa"]="jdocqa,llm-as-a-judge"
     ["mmmu"]="mmmu"
-    ["llava-bench-in-the-wild"]="llm_as_a_judge,rougel"
-    ["jic-vqa"]="jic_vqa"
+    ["llava-bench-in-the-wild"]="llm-as-a-judge,rougel"
+    ["jic-vqa"]="jic-vqa"
     ["mecha-ja"]="mecha-ja"
 )
 
 # Result directories
 declare -a result_dir_list=(
-    "test"
+    "result"
 )
 
 # Main evaluation loop

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -55,7 +55,7 @@ VALID_METRICS = [
     "exact_match",
     "llm_as_a_judge",
     "mmmu",
-    "jic_vqa",
+    "jic-vqa",
     "mecha-ja",
 ]
 

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         model = get_class_from_model_id(args.model_id)(args.model_id)
         preds = []
         logger.info(task.dataset)
-        for doc in tqdm(task.dataset.select(range(task.config.max_dataset_len))):
+        for doc in tqdm(task.dataset):
             images = task.doc_to_visual(doc)
             text = task.doc_to_text(doc)
             if "<image>" in text:

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -4,42 +4,49 @@ import os
 import eval_mm
 from tqdm import tqdm
 import argparse
+import eval_mm.metrics
 from utils import GenerationConfig
 from model_table import get_class_from_model_id
+from dataclasses import asdict
+from loguru import logger
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--model_id", type=str, default="llava-hf/llava-1.5-7b-hf")
-parser.add_argument("--task_id", type=str, default="japanese-heron-bench")
-parser.add_argument("--judge_model", type=str, default="gpt-4o-mini-2024-07-18")
-parser.add_argument("--batch_size_for_evaluation", type=int, default=10)
-parser.add_argument("--overwrite", action="store_true")
-parser.add_argument("--result_dir", type=str, default="result")
-parser.add_argument("--inference_only", action="store_true")
-parser.add_argument("--max_new_tokens", type=int, default=256)
-parser.add_argument("--num_beams", type=int, default=1)
-parser.add_argument("--temperature", type=float, default=0.0)
-parser.add_argument("--top_p", type=float, default=1.0)
-parser.add_argument("--do_sample", action="store_true", default=False)
-parser.add_argument("--use_cache", action="store_true", default=True)
-parser.add_argument(
-    "--max_dataset_len",
-    type=int,
-    default=None,
-    help="max data size for evaluation. If None, use all data. Else, use the first n data.",
-)
-parser.add_argument(
-    "--metrics",
-    type=str,
-    default="llm_as_a_judge_heron_bench",
-    help="metrics to evaluate. You can specify multiple metrics separated by comma (e.g. --metrics exact_match,llm_as_a_judge) You can use rougel,substring_match,jmmmu,jdocqa,llm_as_a_judge_heron_bench,exact_match",
-)
-parser.add_argument(
-    "--rotate_choices",
-    action="store_true",
-    help="If set, rotate the choices of MCQ options for evaluation.",
-)
 
-valid_metrics = [
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_id", type=str, default="llava-hf/llava-1.5-7b-hf")
+    parser.add_argument("--task_id", type=str, default="japanese-heron-bench")
+    parser.add_argument("--judge_model", type=str, default="gpt-4o-mini-2024-07-18")
+    parser.add_argument("--batch_size_for_evaluation", type=int, default=10)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--result_dir", type=str, default="result")
+    parser.add_argument("--inference_only", action="store_true")
+    parser.add_argument("--max_new_tokens", type=int, default=256)
+    parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top_p", type=float, default=1.0)
+    parser.add_argument("--do_sample", action="store_true", default=False)
+    parser.add_argument("--use_cache", action="store_true", default=True)
+    parser.add_argument(
+        "--max_dataset_len",
+        type=int,
+        default=None,
+        help="max data size for evaluation. If None, use all data. Else, use the first n data.",
+    )
+    parser.add_argument(
+        "--metrics",
+        type=str,
+        default="llm_as_a_judge_heron_bench",
+        help="metrics to evaluate. You can specify multiple metrics separated by comma (e.g. --metrics exact_match,llm_as_a_judge) You can use rougel,substring_match,jmmmu,jdocqa,llm_as_a_judge_heron_bench,exact_match",
+    )
+    parser.add_argument(
+        "--rotate_choices",
+        action="store_true",
+        help="If set, rotate the choices of MCQ options for evaluation.",
+    )
+    return parser.parse_args()
+
+
+VALID_METRICS = [
     "rougel",
     "substring_match",
     "jmmmu",
@@ -55,108 +62,111 @@ valid_metrics = [
 
 def validate_metrics(metrics: list[str]):
     for metric in metrics:
-        if metric not in valid_metrics:
+        if metric not in VALID_METRICS:
             raise ValueError(
-                f"Invalid metric: {metric}. Valid metrics are {valid_metrics}"
+                f"Invalid metric: {metric}. Valid metrics are {VALID_METRICS}"
             )
 
 
-args = parser.parse_args()
-
-gen_kwargs = GenerationConfig(
-    max_new_tokens=args.max_new_tokens,
-    temperature=args.temperature,
-    top_p=args.top_p,
-    num_beams=args.num_beams,
-    do_sample=args.do_sample,
-    use_cache=args.use_cache,
-)
-
-task_id = args.task_id
-
-task_config = eval_mm.api.task.TaskConfig(
-    max_dataset_len=args.max_dataset_len,
-    judge_model=args.judge_model,
-    batch_size_for_evaluation=args.batch_size_for_evaluation,
-    rotate_choices=args.rotate_choices,
-)
-task = eval_mm.api.registry.get_task_cls(task_id)(task_config)
-
-output_dir = os.path.join(args.result_dir, task_id, args.model_id)
-os.makedirs(output_dir, exist_ok=True)
-
-# if prediciton is already done, load the prediction
-prediction_path = os.path.join(output_dir, "prediction.jsonl")
-if os.path.exists(prediction_path) and not args.overwrite:
-    with open(prediction_path, "r") as f:
-        preds = [json.loads(line) for line in f]
-    assert (
-        len(preds) == len(task.dataset)
-    ), f"Prediction result length is not equal to the dataset length. Prediction result length: {len(preds)}, Dataset length: {len(task.dataset)}"
-    print(f"Prediction result loaded from {prediction_path}")
-else:
-    model = get_class_from_model_id(args.model_id)(args.model_id)
-    preds = []
-    print(task.dataset)
-    for doc in tqdm(task.dataset):
-        images = task.doc_to_visual(doc)
-        text = task.doc_to_text(doc)
-        if "<image>" in text:
-            text = text.replace("<image>", "")
-        qid = task.doc_to_id(doc)
-        generated_text = model.generate(images, text, gen_kwargs)
-        pred = {
-            "question_id": qid,
-            "text": generated_text,
-        }
-        preds.append(pred)
-    with open(prediction_path, "w") as f:
-        for pred in preds:
-            f.write(json.dumps(pred, ensure_ascii=False) + "\n")
-
-
-if args.inference_only:
-    print("Inference only mode. Skip evaluation.")
-    exit()
-print("Evaluation start")
-# evaluate the predictions
-
-metrics = args.metrics.split(",")
-validate_metrics(metrics)
-
-scores_for_each_metric = {}
-
-for metric in metrics:
-    scores_for_each_metric[metric] = task.calc_scores(preds, metric)
-    print(f"Scores for {metric}: {scores_for_each_metric[metric]}")
-
-calculated_metrics = {}
-
-for metric in metrics:
-    calculated_metrics[metric] = task.gather_scores(
-        scores_for_each_metric[metric], metric
+if __name__ == "__main__":
+    args = parse_args()
+    gen_kwargs = GenerationConfig(
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        num_beams=args.num_beams,
+        do_sample=args.do_sample,
+        use_cache=args.use_cache,
     )
-    print(f"{metric}: {calculated_metrics[metric]}")
 
+    task_config = eval_mm.api.task.TaskConfig(
+        max_dataset_len=args.max_dataset_len,
+        judge_model=args.judge_model,
+        batch_size_for_evaluation=args.batch_size_for_evaluation,
+        rotate_choices=args.rotate_choices,
+    )
+    task = eval_mm.api.registry.get_task_cls(args.task_id)(task_config)
 
-with open(prediction_path, "w") as f:
-    for i, pred in enumerate(preds):
-        question_id = pred["question_id"]
-        text = pred["text"]
-        answer = task.doc_to_answer(task.dataset[i])
-        input_text = task.doc_to_text(task.dataset[i])
-        content = {
-            "question_id": question_id,
-            "text": text,
-            "answer": answer,
-            "input_text": input_text,
-        }
-        for metric in metrics:
-            content[metric] = scores_for_each_metric[metric][i]
-        f.write(json.dumps(content, ensure_ascii=False) + "\n")
-print(f"Prediction result saved to {prediction_path}")
+    output_dir = os.path.join(args.result_dir, args.task_id, args.model_id)
+    os.makedirs(output_dir, exist_ok=True)
 
-evaluation_path = os.path.join(output_dir, "evaluation.json")
-with open(evaluation_path, "w") as f:
-    f.write(json.dumps(calculated_metrics, ensure_ascii=False) + "\n")
-print(f"Evaluation result saved to {evaluation_path}")
+    # if prediciton is already done, load the prediction
+    prediction_path = os.path.join(output_dir, "prediction.jsonl")
+    if os.path.exists(prediction_path) and not args.overwrite:
+        with open(prediction_path, "r") as f:
+            preds = [json.loads(line) for line in f]
+        assert (
+            len(preds) == len(task.dataset)
+        ), f"Prediction result length is not equal to the dataset length. Prediction result length: {len(preds)}, Dataset length: {len(task.dataset)}"
+        logger.info(f"Prediction result loaded from {prediction_path}")
+    else:
+        model = get_class_from_model_id(args.model_id)(args.model_id)
+        preds = []
+        logger.info(task.dataset)
+        for doc in tqdm(task.dataset.select(range(task.config.max_dataset_len))):
+            images = task.doc_to_visual(doc)
+            text = task.doc_to_text(doc)
+            if "<image>" in text:
+                text = text.replace("<image>", "")
+            qid = task.doc_to_id(doc)
+            generated_text = model.generate(images, text, gen_kwargs)
+            pred = {
+                "question_id": qid,
+                "text": generated_text,
+            }
+            preds.append(pred)
+        with open(prediction_path, "w") as f:
+            for pred in preds:
+                f.write(json.dumps(pred, ensure_ascii=False) + "\n")
+
+    if args.inference_only:
+        logger.info("Inference only mode. Skip evaluation.")
+        exit()
+    logger.info("Evaluation start")
+    # evaluate the predictions
+
+    metrics = args.metrics.split(",")
+    validate_metrics(metrics)
+
+    scores_for_each_metric = {}
+    calculated_metrics = {}
+
+    for metric in metrics:
+        scorer = eval_mm.metrics.ScorerRegistry.get_scorer(metric)
+        scores = scorer.score(
+            [task.doc_to_answer(doc) for doc in task.dataset],
+            [pred["text"] for pred in preds],
+            docs=task.dataset,
+            client=task.client,
+            judge_model=task.config.judge_model,
+            batch_size=task.config.batch_size_for_evaluation,
+        )
+        logger.info(scores)
+        scores_for_each_metric[metric] = scores
+        logger.info(f"Scores for {metric}: {scores_for_each_metric[metric]}")
+        aggregate_output = scorer.aggregate(scores, docs=task.dataset)
+
+        calculated_metrics[metric] = asdict(aggregate_output)
+        logger.info(f"Aggregate score for {metric}: {aggregate_output}")
+
+    with open(prediction_path, "w") as f:
+        for i, pred in enumerate(preds):
+            question_id = pred["question_id"]
+            text = pred["text"]
+            answer = task.doc_to_answer(task.dataset[i])
+            input_text = task.doc_to_text(task.dataset[i])
+            content = {
+                "question_id": question_id,
+                "text": text,
+                "answer": answer,
+                "input_text": input_text,
+            }
+            for metric in metrics:
+                content[metric] = scores_for_each_metric[metric][i]
+            f.write(json.dumps(content, ensure_ascii=False) + "\n")
+    logger.info(f"Prediction result saved to {prediction_path}")
+
+    evaluation_path = os.path.join(output_dir, "evaluation.jsonl")
+    with open(evaluation_path, "w") as f:
+        f.write(json.dumps(calculated_metrics, ensure_ascii=False) + "\n")
+    logger.info(f"Evaluation result saved to {evaluation_path}")

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -36,7 +36,7 @@ def parse_args():
         "--metrics",
         type=str,
         default="llm_as_a_judge_heron_bench",
-        help="metrics to evaluate. You can specify multiple metrics separated by comma (e.g. --metrics exact_match,llm_as_a_judge) You can use rougel,substring_match,jmmmu,jdocqa,llm_as_a_judge_heron_bench,exact_match",
+        help=f"metrics to evaluate. You can specify multiple metrics separated by comma (e.g. --metrics exact_match,llm_as_a_judge) You can use the following metrics: {list(eval_mm.metrics.ScorerRegistry._scorers.keys())}",
     )
     parser.add_argument(
         "--rotate_choices",
@@ -46,30 +46,19 @@ def parse_args():
     return parser.parse_args()
 
 
-VALID_METRICS = [
-    "rougel",
-    "substring_match",
-    "jmmmu",
-    "jdocqa",
-    "llm_as_a_judge_heron_bench",
-    "exact_match",
-    "llm_as_a_judge",
-    "mmmu",
-    "jic-vqa",
-    "mecha-ja",
-]
-
-
 def validate_metrics(metrics: list[str]):
     for metric in metrics:
-        if metric not in VALID_METRICS:
+        if metric not in list(eval_mm.metrics.ScorerRegistry._scorers.keys()):
             raise ValueError(
-                f"Invalid metric: {metric}. Valid metrics are {VALID_METRICS}"
+                f"Invalid metric: {metric}. You can use the following metrics: {list(eval_mm.metrics.ScorerRegistry._scorers.keys())}"
             )
 
 
 if __name__ == "__main__":
     args = parse_args()
+    metrics = args.metrics.split(",")
+    validate_metrics(metrics)
+
     gen_kwargs = GenerationConfig(
         max_new_tokens=args.max_new_tokens,
         temperature=args.temperature,
@@ -124,9 +113,6 @@ if __name__ == "__main__":
         exit()
     logger.info("Evaluation start")
     # evaluate the predictions
-
-    metrics = args.metrics.split(",")
-    validate_metrics(metrics)
 
     scores_for_each_metric = {}
     calculated_metrics = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "torch>=2.5.1",
     "webdataset>=0.2.111",
     "av>=14.1.0",
+    "loguru>=0.7.3",
 ]
 readme = "README.md"
 license = "Apache-2.0"
@@ -58,6 +59,7 @@ allow-direct-references = true
 
 [dependency-groups]
 dev = [
+    "mypy>=1.15.0",
     "pytest>=8.3.4",
     "seaborn>=0.13.2",
 ]

--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -3,134 +3,23 @@ import os
 import pandas as pd
 from argparse import ArgumentParser
 from typing import Dict, List, Optional
+from loguru import logger
 
-BENCHMARK_METRICS = {
-    "japanese-heron-bench": [
-        "conv",
-        "detail",
-        "complex",
-        "overall",
-        "conv_rel",
-        "detail_rel",
-        "complex_rel",
-        "overall_rel",
-    ],
-    "ja-vlm-bench-in-the-wild": [
-        "rougel",
-        "llm_as_a_judge",
-    ],
-    "ja-vg-vqa-500": [
-        "rougel",
-        "llm_as_a_judge",
-    ],
-    "jdocqa": [
-        "yesno_exact",
-        "factoid_exact",
-        "numerical_exact",
-        "open-ended_bleu",
-        "overall",
-    ],
-    "ja-multi-image-vqa": [
-        "rougel",
-        "llm_as_a_judge",
-    ],
-    "jmmmu": [
-        "Overall-Art and Psychology",
-        "Design",
-        "Music",
-        "Psychology",
-        "Overall-Business",
-        "Accounting",
-        "Economics",
-        "Finance",
-        "Manage",
-        "Marketing",
-        "Overall-Science",
-        "Biology",
-        "Chemistry",
-        "Math",
-        "Physics",
-        "Overall-Health and Medicine",
-        "Basic_Medical_Science",
-        "Clinical_Medicine",
-        "Diagnostics_and_Laboratory_Medicine",
-        "Pharmacy",
-        "Public_Health",
-        "Overall-Tech and Engineering",
-        "Agriculture",
-        "Architecture_and_Engineering",
-        "Computer_Science",
-        "Electronics",
-        "Energy_and_Power",
-        "Materials",
-        "Mechanical_Engineering",
-        "Overall",
-    ],
-    "jic_vqa": ["jafacility20", "jaflower30", "jafood101", "jalandmark10", "average"],
-    "mecha-ja": [
-        "overall",
-        "Factoid",
-        "Non-Factoid",
-        "with_background",
-        "without_background",
-    ],
-    "llava-bench-in-the-wild": [
-        "rougel",
-        "llm_as_a_judge",
-    ],
-    "mmmu": [
-        "Overall-Art and Design",
-        "Art",
-        "Art_Theory",
-        "Design",
-        "Music",
-        "Overall-Business",
-        "Accounting",
-        "Economics",
-        "Finance",
-        "Manage",
-        "Marketing",
-        "Overall-Science",
-        "Biology",
-        "Chemistry",
-        "Geography",
-        "Math",
-        "Physics",
-        "Overall-Health and Medicine",
-        "Basic_Medical_Science",
-        "Clinical_Medicine",
-        "Diagnostics_and_Laboratory_Medicine",
-        "Pharmacy",
-        "Public_Health",
-        "Overall-Humanities and Social Science",
-        "History",
-        "Literature",
-        "Sociology",
-        "Psychology",
-        "Overall-Tech and Engineering",
-        "Agriculture",
-        "Architecture_and_Engineering",
-        "Computer_Science",
-        "Electronics",
-        "Energy_and_Power",
-        "Materials",
-        "Mechanical_Engineering",
-        "Overall",
-    ],
-}
+VALID_METRICS = [
+    "rougel",
+    "substring_match",
+    "jmmmu",
+    "jdocqa",
+    "llm_as_a_judge_heron_bench",
+    "exact_match",
+    "llm_as_a_judge",
+    "mmmu",
+    "jic_vqa",
+    "mecha-ja",
+]
 
-MAIN_METRICS = {
-    "japanese-heron-bench": ["llm_as_a_judge_heron_bench-overall_rel"],
-    "ja-vlm-bench-in-the-wild": ["llm_as_a_judge", "rougel"],
-    "ja-vg-vqa-500": ["llm_as_a_judge"],
-    "jdocqa": ["jdocqa-overall"],
-    "ja-multi-image-vqa": ["rougel"],
-    "jmmmu": ["jmmmu-Overall"],
-    "jic-vqa": ["jic_vqa-average"],
-    "mecha-ja": ["mecha-ja-overall"],
-    "llava-bench-in-the-wild": ["llm_as_a_judge"],
-    "mmmu": ["mmmu-Overall"],
-}
+# {"llm_as_a_judge_heron_bench": {"overall_score": 36.9037848990212, "details": {"conv": 3.238095238095238, "conv_rel": 35.78947368421053, "detail": 3.1904761904761907, "detail_rel": 36.61202185792351, "complex": 3.4, "complex_rel": 38.309859154929576, "parse_error_count": 0, "overall": 3.29126213592233, "overall_rel": 36.9037848990212}}}
+
 
 TASK_ALIAS = {
     "japanese-heron-bench": "Heron",
@@ -146,92 +35,78 @@ TASK_ALIAS = {
 }
 
 METRIC_ALIAS = {
-    "llm_as_a_judge_heron_bench-overall_rel": "LLM",
+    "llm_as_a_judge_heron_bench": "LLM",
     "llm_as_a_judge": "LLM",
     "rougel": "Rouge",
-    "jdocqa-overall": "Acc",
-    "jmmmu-Overall": "Acc",
-    "jic_vqa-average": "Acc",
-    "mecha-ja-overall": "Acc",
-    "mmmu-Overall": "Acc",
+    "jdocqa": "Acc",
+    "jmmmu": "Acc",
+    "jic_vqa": "Acc",
+    "mecha-ja": "Acc",
+    "mmmu": "Acc",
 }
-
-
-def read_evaluation_jsonl(file_path: str) -> Dict:
-    merged_result = {}
-    with open(file_path, "r") as f:
-        for line in f:
-            data = json.loads(line)
-            merged_result.update(data)
-    return merged_result
 
 
 def main(result_dir: str, model_list: List[str], output_path: Optional[str] = None):
     task_dirs = [d for d in os.listdir(result_dir) if not d.startswith(".")]
 
-    print(f"Tasks found: {task_dirs}")
     df = pd.DataFrame()
 
     for model in model_list:
         model_results = {"Model": model}
 
         for task_dir in task_dirs:
-            eval_path = os.path.join(result_dir, task_dir, model, "evaluation.json")
+            logger.info(f"Reading {task_dir} evaluation results for {model}")
+            eval_path = os.path.join(result_dir, task_dir, model, "evaluation.jsonl")
             if not os.path.exists(eval_path):
-                print(f"Warning: {eval_path} not found.")
+                logger.warning(f"{eval_path} not found. Skipping...")
                 continue
 
-            evaluation = read_evaluation_jsonl(eval_path)
+            with open(eval_path, "r") as f:
+                evaluation = json.load(f)
+            logger.info(f"Results: {evaluation}")
+            # {'llm_as_a_judge': {'overall_score': 2.7, 'details': {'llm_as_a_judge': 2.7}}, 'rougel': {'overall_score': 40.75248314834134, 'details': {'rougel': 40.75248314834134}}}
 
-            # ネストされている形式にも対応
-            for key, val in evaluation.items():
-                if isinstance(val, dict):
-                    for sub_metric, sub_val in val.items():
-                        if sub_metric == "parse_error_count":
-                            continue  # スキップしたい項目
-                        model_results[f"{task_dir}-{key}-{sub_metric}"] = sub_val
-                else:
-                    model_results[f"{task_dir}-{key}"] = val
+            for metric, aggregate_output in evaluation.items():
+                if metric not in VALID_METRICS:
+                    continue
 
-        df = pd.concat([df, pd.DataFrame([model_results])], ignore_index=True)
-
-    # 全体結果出力
-    print("\n## Full Benchmark Result")
-    print(df.to_markdown(mode="github", index=False))
-
-    # メインのメトリクスだけを抽出
-    main_df = df[["Model"]]
-    for task, metrics in MAIN_METRICS.items():
-        for metric in metrics:
-            print(f"{task}-{metric}")
-            if f"{task}-{metric}" in df.columns:
-                print(f"{metric}: {df[f'{task}-{metric}'].mean()}")
-                main_df[f"{TASK_ALIAS[task]}-{METRIC_ALIAS[metric]}"] = df[
-                    f"{task}-{metric}"
+                model_results[f"{task_dir}/{metric}"] = aggregate_output[
+                    "overall_score"
                 ]
-            else:
-                main_df[f"{TASK_ALIAS[task]}-{METRIC_ALIAS[metric]}"] = None
 
-    print("\n## Main Metrics")
-    print(main_df.to_markdown(mode="github", index=False))
+        df = df._append(model_results, ignore_index=True)
 
-    if output_path:
-        with open(output_path, "w") as f:
-            f.write(main_df.to_markdown(mode="github", index=False))
+    df = df.set_index("Model")
+    df = df.rename(
+        columns={
+            k: f"{TASK_ALIAS[k.split('/')[0]]}/{METRIC_ALIAS[k.split('/')[1]]}"
+            for k in df.columns
+        }
+    )
+
+    print(df.to_markdown(mode="github"))
+
+    with open(output_path, "w") as f:
+        f.write(df.to_markdown(mode="github"))
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--result_dir", type=str, default="result")
+    parser.add_argument("--output_path", type=str, default="leaderboard.md")
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
-    parser.add_argument("--result_dir", type=str, default="paper")
-    parser.add_argument("--output_path", type=str, default="leaderboard.md")
-    args = parser.parse_args()
+    args = parse_args()
 
     # モデルは実行時引数でも取れるようにしても良い
     model_list = [
-        "Qwen/Qwen2.5-VL-7B-Instruct",
-        "sbintuitions/sarashina2-vision-8b",
-        "sbintuitions/sarashina2-vision-14b",
-        "google/gemma-3-12b-it",
+        # "Qwen/Qwen2.5-VL-7B-Instruct",
+        # "sbintuitions/sarashina2-vision-8b",
+        # "sbintuitions/sarashina2-vision-14b",
+        # "google/gemma-3-12b-it",
+        "llava-hf/llava-1.5-7b-hf"
     ]
 
     main(args.result_dir, model_list, args.output_path)

--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -4,19 +4,8 @@ import pandas as pd
 from argparse import ArgumentParser
 from typing import Dict, List, Optional
 from loguru import logger
-
-VALID_METRICS = [
-    "rougel",
-    "substring_match",
-    "jmmmu",
-    "jdocqa",
-    "llm_as_a_judge_heron_bench",
-    "exact_match",
-    "llm_as_a_judge",
-    "mmmu",
-    "jic_vqa",
-    "mecha-ja",
-]
+import eval_mm
+import eval_mm.metrics
 
 # {"llm_as_a_judge_heron_bench": {"overall_score": 36.9037848990212, "details": {"conv": 3.238095238095238, "conv_rel": 35.78947368421053, "detail": 3.1904761904761907, "detail_rel": 36.61202185792351, "complex": 3.4, "complex_rel": 38.309859154929576, "parse_error_count": 0, "overall": 3.29126213592233, "overall_rel": 36.9037848990212}}}
 
@@ -35,12 +24,12 @@ TASK_ALIAS = {
 }
 
 METRIC_ALIAS = {
-    "llm_as_a_judge_heron_bench": "LLM",
-    "llm_as_a_judge": "LLM",
+    "heron-bench": "LLM",
+    "llm-as-a-judge": "LLM",
     "rougel": "Rouge",
     "jdocqa": "Acc",
     "jmmmu": "Acc",
-    "jic_vqa": "Acc",
+    "jic-vqa": "Acc",
     "mecha-ja": "Acc",
     "mmmu": "Acc",
 }
@@ -67,7 +56,8 @@ def main(result_dir: str, model_list: List[str], output_path: Optional[str] = No
             # {'llm_as_a_judge': {'overall_score': 2.7, 'details': {'llm_as_a_judge': 2.7}}, 'rougel': {'overall_score': 40.75248314834134, 'details': {'rougel': 40.75248314834134}}}
 
             for metric, aggregate_output in evaluation.items():
-                if metric not in VALID_METRICS:
+                if metric not in list(eval_mm.metrics.ScorerRegistry._scorers.keys()):
+                    logger.warning(f"Skipping unsupported metric: {metric}")
                     continue
 
                 model_results[f"{task_dir}/{metric}"] = aggregate_output[
@@ -102,11 +92,11 @@ if __name__ == "__main__":
 
     # モデルは実行時引数でも取れるようにしても良い
     model_list = [
-        # "Qwen/Qwen2.5-VL-7B-Instruct",
-        # "sbintuitions/sarashina2-vision-8b",
-        # "sbintuitions/sarashina2-vision-14b",
-        # "google/gemma-3-12b-it",
-        "llava-hf/llava-1.5-7b-hf"
+        "Qwen/Qwen2.5-VL-7B-Instruct",
+        "sbintuitions/sarashina2-vision-8b",
+        "sbintuitions/sarashina2-vision-14b",
+        "google/gemma-3-12b-it",
+        "llava-hf/llava-1.5-7b-hf",
     ]
 
     main(args.result_dir, model_list, args.output_path)

--- a/src/eval_mm/api/task.py
+++ b/src/eval_mm/api/task.py
@@ -57,13 +57,3 @@ class Task(abc.ABC):
     def doc_to_answer(self, doc) -> str:
         """Converts a document to answer."""
         pass
-
-    @abc.abstractmethod
-    def calc_scores(self, preds: list, metric: str) -> list:
-        """Calculates scores for the predictions."""
-        pass
-
-    @abc.abstractmethod
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        """Aggregates the scores."""
-        pass

--- a/src/eval_mm/metrics/__init__.py
+++ b/src/eval_mm/metrics/__init__.py
@@ -23,7 +23,7 @@ class ScorerRegistry:
         "jmmmu": JMMMUScorer,
         "jdocqa": JDocQAScorer,
         "mmmu": MMMUScorer,
-        "jic_vqa": JICVQAScorer,
+        "jic-vqa": JICVQAScorer,
         "mecha-ja": MECHAJaScorer,
     }
 

--- a/src/eval_mm/metrics/__init__.py
+++ b/src/eval_mm/metrics/__init__.py
@@ -15,11 +15,11 @@ class ScorerRegistry:
     """Registry to map metrics to their corresponding scorer classes."""
 
     _scorers = {
-        "llm_as_a_judge_heron_bench": HeronBenchScorer,
-        "exact_match": ExactMatchScorer,
-        "llm_as_a_judge": LlmAsaJudgeScorer,
+        "heron-bench": HeronBenchScorer,
+        "exact-match": ExactMatchScorer,
+        "llm-as-a-judge": LlmAsaJudgeScorer,
         "rougel": RougeLScorer,
-        "substring_match": SubstringMatchScorer,
+        "substring-match": SubstringMatchScorer,
         "jmmmu": JMMMUScorer,
         "jdocqa": JDocQAScorer,
         "mmmu": MMMUScorer,

--- a/src/eval_mm/metrics/exact_match_scorer.py
+++ b/src/eval_mm/metrics/exact_match_scorer.py
@@ -1,4 +1,4 @@
-from .scorer import Scorer
+from .scorer import Scorer, AggregateOutput
 
 
 class ExactMatchScorer(Scorer):
@@ -8,5 +8,20 @@ class ExactMatchScorer(Scorer):
         return scores
 
     @staticmethod
-    def aggregate(scores: list[int], **kwargs) -> float:
-        return sum(scores) / len(scores)
+    def aggregate(scores: list[int], **kwargs) -> AggregateOutput:
+        mean = sum(scores) / len(scores)
+        return AggregateOutput(mean, {"exact_match": mean})
+
+
+def test_exact_match_scorer():
+    scorer = ExactMatchScorer()
+    refs = ["私は猫です。", "私は犬です。"]
+    preds = ["私は犬です。", "私は犬です。"]
+    scores = scorer.score(refs, preds)
+    assert scores == [0, 1]
+    scores = scorer.aggregate([1, 1, 1, 0])
+    assert scores.overall_score == 0.75
+    assert scores.details == {"exact_match": 0.75}
+    scores = scorer.aggregate([1, 1, 0, 0])
+    assert scores.overall_score == 0.5
+    assert scores.details == {"exact_match": 0.5}

--- a/src/eval_mm/metrics/jic_vqa_scorer.py
+++ b/src/eval_mm/metrics/jic_vqa_scorer.py
@@ -1,4 +1,4 @@
-from .scorer import Scorer
+from .scorer import Scorer, AggregateOutput
 
 
 class JICVQAScorer(Scorer):
@@ -8,7 +8,7 @@ class JICVQAScorer(Scorer):
         return scores
 
     @staticmethod
-    def aggregate(scores: list[int], **kwargs) -> float:
+    def aggregate(scores: list[int], **kwargs) -> AggregateOutput:
         docs = kwargs["docs"]
         domain_scores = {}
 
@@ -32,5 +32,15 @@ class JICVQAScorer(Scorer):
             result["average"] = sum(domain_averages) / len(domain_averages)
         else:
             result["average"] = 0.0
+        output = AggregateOutput(result["average"], result)
+        return output
 
-        return result
+
+def test_jic_vqa_test():
+    refs = ["私は猫です。"]
+    preds = ["私は猫です。"]
+    scores = JICVQAScorer.score(refs, preds, docs={"domain": ["test"]})
+    assert scores == [1]
+    output = JICVQAScorer.aggregate(scores, docs={"domain": ["test"]})
+    assert output.overall_score == 1.0
+    assert output.details == {"test": 1.0, "average": 1.0}

--- a/src/eval_mm/metrics/llm_as_a_judge_scorer.py
+++ b/src/eval_mm/metrics/llm_as_a_judge_scorer.py
@@ -1,4 +1,4 @@
-from eval_mm.metrics.scorer import Scorer
+from eval_mm.metrics.scorer import Scorer, AggregateOutput
 from tqdm import tqdm
 import re
 
@@ -76,8 +76,9 @@ class LlmAsaJudgeScorer(Scorer):
         #         scores[i] = 0
         return scores
 
-    def aggregate(scores: list, **kwargs) -> float:
-        return sum([score for score in scores]) / len(scores)
+    def aggregate(scores: list, **kwargs) -> AggregateOutput:
+        mean = sum(scores) / len(scores)
+        return AggregateOutput(mean, {"llm_as_a_judge": mean})
 
 
 def test_llm_as_a_judge_scorer():
@@ -96,8 +97,9 @@ def test_llm_as_a_judge_scorer():
         batch_size=batch_size,
     )
     assert scores == [0, 0]
-    scores = LlmAsaJudgeScorer.aggregate(scores)
-    assert scores == 0.0
+    output = LlmAsaJudgeScorer.aggregate(scores)
+    assert output.overall_score == 0.0
+    assert output.details == {"llm_as_a_judge": 0.0}
 
     import os
 

--- a/src/eval_mm/metrics/rougel_scorer.py
+++ b/src/eval_mm/metrics/rougel_scorer.py
@@ -5,7 +5,7 @@ from rouge_score import rouge_scorer, scoring
 from fugashi import Tagger
 import emoji
 import unicodedata
-from .scorer import Scorer
+from .scorer import Scorer, AggregateOutput
 from concurrent.futures import ProcessPoolExecutor
 
 
@@ -84,8 +84,9 @@ class RougeLScorer(Scorer):
         return scores
 
     @staticmethod
-    def aggregate(scores: list[dict], **kwargs) -> float:
-        return sum(scores) / len(scores)
+    def aggregate(scores: list[dict], **kwargs) -> AggregateOutput:
+        mean = sum(scores) / len(scores)
+        return AggregateOutput(mean, {"rougel": mean})
 
 
 def test_rouge_ja():
@@ -121,6 +122,5 @@ def test_rougel_scorer():
     preds = ["たかしが公園にいたようだ。"]
     scores = RougeLScorer.score(refs, preds)
     assert pytest.approx(scores[0], 0.01) == 66.66
-
-    assert RougeLScorer.aggregate([100.0, 100.0, 100.0, 0.0]) == 75.0
-    assert RougeLScorer.aggregate([100.0, 100.0, 0.0, 0.0]) == 50.0
+    output = RougeLScorer.aggregate(scores)
+    assert pytest.approx(output.overall_score, 0.01) == 66.66

--- a/src/eval_mm/metrics/scorer.py
+++ b/src/eval_mm/metrics/scorer.py
@@ -1,14 +1,23 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class AggregateOutput:
+    overall_score: float
+    details: dict[str, float]
 
 
 class Scorer(ABC):
     def __init__(self) -> None:
         pass
 
+    @staticmethod
     @abstractmethod
-    def score(refs: list[str], preds: list[str], **kwargs) -> list:
+    def score(refs: list[str], preds: list[str], **kwargs) -> list[int | float]:
         raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
-    def aggregate(scores: list, **kwargs) -> object:
+    def aggregate(scores: list, **kwargs) -> AggregateOutput:
         raise NotImplementedError

--- a/src/eval_mm/metrics/substring_match_scorer.py
+++ b/src/eval_mm/metrics/substring_match_scorer.py
@@ -1,4 +1,4 @@
-from .scorer import Scorer
+from .scorer import Scorer, AggregateOutput
 
 
 class SubstringMatchScorer(Scorer):
@@ -8,8 +8,9 @@ class SubstringMatchScorer(Scorer):
         return scores
 
     @staticmethod
-    def aggregate(scores: list[int], **kwargs) -> float:
-        return sum(scores) / len(scores)
+    def aggregate(scores: list[int], **kwargs) -> AggregateOutput:
+        mean = sum(scores) / len(scores)
+        return AggregateOutput(mean, {"substring_match": mean})
 
 
 def test_substring_match_scorer():
@@ -30,17 +31,6 @@ def test_substring_match_scorer():
     scores = SubstringMatchScorer.score(refs, preds)
     assert scores == [0]
 
-    scores = SubstringMatchScorer.aggregate([1, 1, 1, 0])
-    assert scores == 0.75
-
-    scores = SubstringMatchScorer.aggregate([1, 1, 0, 0])
-    assert scores == 0.5
-
-    scores = SubstringMatchScorer.aggregate([1, 0, 0, 0])
-    assert scores == 0.25
-
-    scores = SubstringMatchScorer.aggregate([0, 0, 0, 0])
-    assert scores == 0.0
-
-    scores = SubstringMatchScorer.aggregate([1, 1, 1, 1])
-    assert scores == 1.0
+    output = SubstringMatchScorer.aggregate([1, 1, 1, 0])
+    assert output.overall_score == 0.75
+    assert output.details == {"substring_match": 0.75}

--- a/src/eval_mm/tasks/ja_multi_image_vqa.py
+++ b/src/eval_mm/tasks/ja_multi_image_vqa.py
@@ -3,7 +3,6 @@ import re
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 # import neologdn FIXME: fix c++12 error when installing neologdn
@@ -36,25 +35,6 @@ class JAMultiImageVQA(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        scorer = ScorerRegistry.get_scorer(metric)
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str):
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {"docs": self.dataset}
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -67,5 +47,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/ja_vg_vqa_500.py
+++ b/src/eval_mm/tasks/ja_vg_vqa_500.py
@@ -2,7 +2,6 @@ from datasets import Dataset, concatenate_datasets, load_dataset
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 
@@ -49,26 +48,6 @@ class JaVGVQA500(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "batch_size": self.config.batch_size_for_evaluation,
-            "judge_model": self.config.judge_model,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> float:
-        """Gather scores of each prediction based on the metric."""
-        kwargs = {"docs": self.dataset}
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -81,5 +60,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/ja_vlm_bench_in_the_wild.py
+++ b/src/eval_mm/tasks/ja_vlm_bench_in_the_wild.py
@@ -2,7 +2,6 @@ from datasets import Dataset, load_dataset
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 
@@ -32,25 +31,6 @@ class JaVLMBenchIntheWild(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list, metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str):
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {"docs": self.dataset}
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -63,5 +43,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/japanese_heron_bench.py
+++ b/src/eval_mm/tasks/japanese_heron_bench.py
@@ -2,7 +2,6 @@ from datasets import load_dataset, Dataset
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 
@@ -30,26 +29,6 @@ class JapaneseHeronBench(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]["gpt-4-0125-preview"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"]["gpt-4-0125-preview"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        """Gather scores of each prediction based on the metric."""
-        kwargs = {"docs": self.dataset}
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -62,5 +41,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/jdocqa.py
+++ b/src/eval_mm/tasks/jdocqa.py
@@ -3,7 +3,6 @@ from pdf2image import convert_from_path
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 
 import aiohttp
 from PIL import Image
@@ -75,25 +74,6 @@ class JDocQA(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        kwargs = {"docs": self.dataset}
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -106,5 +86,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/jic_vqa.py
+++ b/src/eval_mm/tasks/jic_vqa.py
@@ -3,7 +3,6 @@ from datasets import Dataset, load_dataset
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 import os
 
 
@@ -37,25 +36,6 @@ class JICVQA(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str):
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {"docs": self.dataset}
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -68,5 +48,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/jmmmu.py
+++ b/src/eval_mm/tasks/jmmmu.py
@@ -12,7 +12,6 @@ from ..api.task import Task
 
 import ast
 import re
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 
@@ -118,26 +117,6 @@ class JMMMU(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "batch_size": self.config.batch_size_for_evaluation,
-            "judge_model": self.config.judge_model,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        """Gather scores of each prediction based on the metric."""
-        kwargs = {"docs": self.dataset}
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -150,5 +129,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), str)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/llava_bench_in_the_wild.py
+++ b/src/eval_mm/tasks/llava_bench_in_the_wild.py
@@ -2,7 +2,6 @@ from datasets import Dataset, load_dataset
 
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 
@@ -32,25 +31,6 @@ class LlavaBenchIntheWild(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "judge_model": self.config.judge_model,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str):
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {"docs": self.dataset}
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -63,5 +43,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), int)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/mecha_ja.py
+++ b/src/eval_mm/tasks/mecha_ja.py
@@ -1,7 +1,6 @@
 from datasets import Dataset, load_dataset
 from ..api.registry import register_task
 from ..api.task import Task
-from eval_mm.metrics import ScorerRegistry
 from PIL import Image
 
 MULTI_CHOICE_PROMPT = (
@@ -158,20 +157,6 @@ class MECHAJa(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer_text"]
 
-    def calc_scores(self, preds: list, metric: str) -> list:
-        scorer = ScorerRegistry.get_scorer(metric)
-        refs = [doc["answer_text"] for doc in self.dataset]
-        pred_texts = [p["text"] for p in preds]
-        kwargs = {
-            "docs": self.dataset,
-            "batch_size": self.config.batch_size_for_evaluation,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, docs=self.dataset)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -184,5 +169,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), str)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)

--- a/src/eval_mm/tasks/mmmu.py
+++ b/src/eval_mm/tasks/mmmu.py
@@ -13,7 +13,6 @@ from PIL import Image
 
 import ast
 import re
-from eval_mm.metrics import ScorerRegistry
 
 MULTI_CHOICE_PROMPT = "Answer with the option's letter from the given choices directly."
 OPEN_ENDED_PROMPT = "Answer the question using a single word or phrase."
@@ -118,26 +117,6 @@ class MMMU(Task):
     def doc_to_answer(doc) -> str:
         return doc["answer"]
 
-    def calc_scores(self, preds: list[dict], metric: str) -> list:
-        """Calculate scores of each prediction based on the metric."""
-        docs = self.dataset
-        refs = [doc["answer"] for doc in docs]
-        pred_texts = [pred["text"] for pred in preds]
-        scorer = ScorerRegistry.get_scorer(metric)
-        kwargs = {
-            "docs": docs,
-            "client": self.client,
-            "batch_size": self.config.batch_size_for_evaluation,
-            "judge_model": self.config.judge_model,
-        }
-        return scorer.score(refs, pred_texts, **kwargs)
-
-    def gather_scores(self, scores: list[dict], metric: str) -> dict:
-        """Gather scores of each prediction based on the metric."""
-        kwargs = {"docs": self.dataset}
-        scorer = ScorerRegistry.get_scorer(metric)
-        return scorer.aggregate(scores, **kwargs)
-
 
 def test_task():
     from eval_mm.api.task import TaskConfig
@@ -150,5 +129,3 @@ def test_task():
     assert isinstance(task.doc_to_visual(ds[0])[0], Image.Image)
     assert isinstance(task.doc_to_id(ds[0]), str)
     assert isinstance(task.doc_to_answer(ds[0]), str)
-    assert isinstance(task.calc_scores([{"text": "dummy"}], "rougel"), list)
-    assert isinstance(task.gather_scores([0.0, 100.0], "rougel"), float)


### PR DESCRIPTION
- Scorer.aggregate()のoutput typeを統一
- task classのcalc_score(), gather_score()は不要だったので削除