### PR TITLE
add z-score calc. configuration at make_leaderboard.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,17 @@ __depr__/
 
 # examples/llava for evaluating LLM-jp-3 VILA
 examples/llava/*
+
+# experiments
+result/
+
+# uv.lock
+uv.lock
+
+# cursor config
+.cursor/
+.cursorrules
+.cursorignore
+
+# vscode
+.vscode/

--- a/examples/japanese_stable_vlm.py
+++ b/examples/japanese_stable_vlm.py
@@ -176,11 +176,14 @@ class VLM(BaseVLM):
         self.model.to(self.device)
 
     def generate(
-        self, images, text: str, gen_kwargs: GenerationConfig = GenerationConfig()
+        self,
+        images: list[Image.Image] | None,
+        text: str,
+        gen_kwargs: GenerationConfig = GenerationConfig(),
     ) -> str:
         # instruct blip does not expect the <image> tag
         prompt = build_prompt(task="vqa", input=text)
-        if len(images) == 0:
+        if images is None:
             raise ValueError("Please provide at least one image.")
 
         else:


### PR DESCRIPTION
@speed1313 @odashi 

## 関係するissue

This PR closes #158 

## やったこと

暫定的な措置として、以下のようにリーダーボードの横に総合偏差値・カテゴリ別の偏差値が出るようにしました。
ROUGEを評価指標として求めたベンチマークスコアは、偏差値の計算に利用しませんでした。

## どうなっているか

| Model                                    | 総合偏差値       | 非日本語偏差値     | 視覚中心偏差値     | 言語・知識中心偏差値   | VG-VQA/LLM   | MMMU/Acc    | JMMMU/Acc   | JVB-ItW/LLM   | JDocQA/Acc   | JDocQA/LLM   | MECHA/Acc   | JIC/Acc     | MulIm-VQA/LLM   | LLAVA/LLM   | Heron/LLM   |
|:-----------------------------------------|:------------|:------------|:------------|:-------------|:-------------|:------------|:------------|:--------------|:-------------|:-------------|:------------|:------------|:----------------|:------------|:------------|
| stabilityai/japanese-instructblip-alpha  | 36.4        | 36.0        | 33.2        | 40.0         | 2.97         | 25.56       | 26.44       | 2.26          | 12.4         | 2.08         | 23.39       | 56.63       | 2.44            | 1.25        | 23.53       |
| stabilityai/japanese-stable-vlm          | 37.4        | 31.6        | 46.5        | 34.0         | 3.47         | 7.11        | 3.41        | 3.28          | 13.09        | 2.09         | 4.83        | 69.27       | 2.33            | 1.4         | 48.44       |
| SakanaAI/Llama-3-EvoVLM-JP-v2            | 47.7        | 48.3        | 46.6        | 48.2         | 3.43         | 38.89       | 36.36       | 3.48          | 15.45        | 2.35         | 50.74       | 67.05       | 3.13            | 2.87        | 47.59       |
| cyberagent/llava-calm2-siglip            | 40.1        | 40.2        | 47.6        | 32.5         | 3.57         | 26.67       | 6.14        | 3.66          | 8.15         | 2.05         | 11.2        | 58.48       | 2.75            | 1.95        | 54.1        |
| llm-jp/llm-jp-3-vila-14b                 | 51.4        | 50.1        | 57.7        | 46.3         | <u>3.9</u>   | 32.67       | 19.02       | 4.08          | 17.34        | 2.51         | 45.63       | 81.35       | 3.51            | 3.35        | 68.03       |
| sbintuitions/sarashina2-vision-8b        | 51.1        | 42.3        | 54.8        | 56.1         | 3.72         | 29.67       | 39.17       | 4.06          | 22.61        | 2.98         | 56.29       | 78.68       | 2.62            | 2.45        | 60.45       |
| sbintuitions/sarashina2-vision-14b       | 52.5        | 43.7        | 54.9        | 59.0         | 3.72         | 33.78       | 42.95       | 4.04          | <u>23.9</u>  | 3.07         | 64.42       | 80.03       | 2.64            | 2.52        | 60.15       |
| MIL-UT/Asagi-14B                         | 35.8        | 32.9        | 36.7        | 37.8         | 1.96         | 15.33       | 21.74       | 2.9           | 10.38        | 1.99         | 24.05       | 76.2        | 2.0             | 1.57        | 41.85       |
| llava-hf/llava-1.5-7b-hf                 | 42.1        | 44.9        | 37.2        | 44.2         | 2.98         | 34.0        | 29.62       | 3.02          | 14.79        | 2.17         | 38.17       | 43.99       | 2.55            | 2.93        | 43.14       |
| llava-hf/llava-v1.6-mistral-7b-hf        | 41.8        | 45.6        | 37.8        | 41.9         | 3.05         | 35.89       | 25.45       | 2.92          | 14.38        | 1.98         | 34.43       | 58.22       | 2.31            | 3.25        | 30.04       |
| neulab/Pangea-7B-hf                      | 53.2        | 53.0        | 57.0        | 49.6         | **4.1**      | 43.67       | 37.42       | 3.86          | 16.17        | 2.36         | 56.51       | 85.57       | 3.38            | 3.52        | 56.97       |
| mistralai/Pixtral-12B-2409               | 51.1        | 57.6        | 49.8        | 46.0         | 3.52         | 48.56       | 18.71       | 3.9           | 14.77        | 2.44         | 56.4        | 61.07       | 4.11            | 3.63        | 60.88       |
| meta-llama/Llama-3.2-11B-Vision-Instruct | 48.4        | 49.3        | 46.2        | 49.7         | 3.32         | 38.22       | 34.62       | 3.36          | 17.61        | 2.52         | 49.31       | 78.71       | 2.64            | 3.7         | 38.08       |
| Efficient-Large-Model/VILA1.5-13b        | 46.9        | 50.7        | 43.8        | 46.2         | 3.23         | 37.0        | 33.48       | 3.48          | 14.82        | 2.22         | 46.35       | 58.2        | 3.16            | 3.6         | 46.93       |
| OpenGVLab/InternVL2-8B                   | 50.2        | 50.7        | 47.2        | 52.6         | 3.48         | 49.67       | 39.09       | 3.52          | 19.79        | 2.7          | 50.52       | 65.73       | 2.89            | 3.07        | 49.82       |
| OpenGVLab/InternVL2-26B                  | 51.2        | 54.7        | 49.2        | 49.8         | 3.65         | 48.22       | 39.02       | 3.08          | 15.28        | 2.6          | 51.29       | 73.92       | 3.31            | 3.75        | 59.69       |
| Qwen/Qwen2.5-VL-7B-Instruct              | 60.0        | 59.1        | 57.8        | 63.0         | 3.69         | 50.0        | 48.18       | 4.28          | **26.5**     | <u>3.6</u>   | 60.02       | 82.66       | 4.11            | 3.93        | 70.29       |
| Qwen/Qwen2.5-VL-32B-Instruct             | 59.4        |             | 59.4        |              | 3.76         |             |             | 4.3           |              |              |             |             |                 |             | 74.8        |
| Qwen/Qwen2.5-VL-72B-Instruct             | **65.3**    | **65.6**    | <u>63.2</u> | **67.1**     | 3.89         | **63.0**    | **60.6**    | <u>4.4</u>    | 23.92        | **3.9**      | <u>74.7</u> | <u>90.4</u> | **4.8**         | <u>4.0</u>  | <u>85.5</u> |
| google/gemma-3-4b-it                     | 51.2        | 53.8        | 49.8        | 50.1         | 3.43         | 40.67       | 36.97       | 3.68          | 17.55        | 2.59         | 47.17       | 75.36       | 3.71            | 3.57        | 52.83       |
| google/gemma-3-12b-it                    | 58.5        | 59.4        | 59.0        | 57.1         | 3.74         | 48.11       | 47.58       | 4.3           | 20.13        | 2.98         | 62.6        | 85.72       | 4.22            | 4.02        | 72.19       |
| google/gemma-3-27b-it                    | 59.9        | 61.5        | 59.3        | 58.8         | 3.75         | <u>56.1</u> | 50.53       | 4.36          | 20.17        | 3.1          | 67.66       | 88.23       | 4.33            | 3.93        | 69.15       |
| microsoft/Phi-4-multimodal-instruct      | 50.4        | 54.9        | 41.7        | 54.6         | 3.3          | 53.67       | 39.17       | 3.2           | 22.85        | 2.9          | 46.35       | 52.27       | 3.38            | 3.37        | 45.52       |
| gpt-4o-2024-11-20                        | <u>65.1</u> | <u>64.0</u> | **65.8**    | <u>65.4</u>  | 3.93         | 56.11       | <u>57.5</u> | **4.4**       | 22.0         | 3.59         | **83.7**    | **95.8**    | <u>4.8</u>      | **4.1**     | **93.7**    |