### PR TITLE
refactor: EN/JA task classification via metadata cluster (#185)

### DIFF
--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -15,6 +15,7 @@ from eval_mm.metadata import (
     get_task_alias,
     get_task_cluster_alias,
     get_metric_alias,
+    get_tasks_by_language,
     LEADERBOARD_MODELS,
     write_github_pages_json,
 )
@@ -23,6 +24,7 @@ TASK_ALIAS = get_task_alias()
 TASK_CLUSTER_ALIAS = get_task_cluster_alias()
 METRIC_ALIAS = get_metric_alias()
 MODEL_LIST = LEADERBOARD_MODELS
+ENGLISH_TASKS, JAPANESE_TASKS = get_tasks_by_language()
 
 
 def load_evaluation_data(result_dir: str, model: str, task_dirs: list[str]) -> dict:
@@ -144,14 +146,9 @@ def plot_correlation(df: pd.DataFrame, filename: str, tex_columns: list[str] = N
     df = df.rename(columns=rename_dict)
     
     # Define task order as in TeX output: English tasks → Japanese tasks
-    task_order = [
-        # English tasks (from en_task_order)
-        "OK-VQA", "TextVQA", "AI2D", "ChartQA", "DocVQA", "BLINK", "InfoVQA", "MMMU", "LLAVA",
-        # Japanese tasks (from ja_task_order)
-        "CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"
-    ]
-    english_tasks = {"OK-VQA", "TextVQA", "AI2D", "ChartQA", "DocVQA", "BLINK", "InfoVQA", "MMMU", "LLAVA"}
-    japanese_tasks = {"CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"}
+    task_order = ENGLISH_TASKS + JAPANESE_TASKS
+    english_tasks = set(ENGLISH_TASKS)
+    japanese_tasks = set(JAPANESE_TASKS)
     
     # Filter and reorder dataframe columns based on task_order
     available_tasks = [task for task in task_order if task in df.columns]
@@ -249,8 +246,8 @@ def calculate_average_correlations(df: pd.DataFrame, tex_columns: list[str] = No
     df = df.rename(columns=rename_dict)
     
     # Define English and Japanese tasks
-    english_tasks = ["OK-VQA", "TextVQA", "AI2D", "ChartQA", "DocVQA", "BLINK", "InfoVQA", "MMMU", "LLAVA"]
-    japanese_tasks = ["CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"]
+    english_tasks = ENGLISH_TASKS
+    japanese_tasks = JAPANESE_TASKS
     
     # Filter available tasks
     available_english = [task for task in english_tasks if task in df.columns]
@@ -318,13 +315,8 @@ def plot_task_clustering(df: pd.DataFrame, filename: str, tex_columns: list[str]
     df = df.rename(columns=rename_dict)
     
     # Define task order as in TeX output: English tasks → Japanese tasks
-    task_order = [
-        # English tasks
-        "OK-VQA", "TextVQA", "AI2D", "ChartQA", "DocVQA", "BLINK", "InfoVQA", "MMMU", "LLAVA",
-        # Japanese tasks
-        "CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"
-    ]
-    japanese_tasks = {"CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"}
+    task_order = ENGLISH_TASKS + JAPANESE_TASKS
+    japanese_tasks = set(JAPANESE_TASKS)
     
     # Filter and reorder dataframe columns based on task_order
     available_tasks = [task for task in task_order if task in df.columns]
@@ -471,11 +463,9 @@ def format_output(df: pd.DataFrame, output_format: str) -> str:
 def export_to_tex_files(df: pd.DataFrame, ja_tasks: list[str], en_tasks: list[str]):
     """Export leaderboard results to LaTeX table files like artifact/result_*.tex."""
     
-    # Define desired task order for Japanese tasks
-    ja_task_order = ["CVQA", "CC-OCR", "JIC", "MulIm-VQA", "JMMMU", "JDocQA", "JVB-ItW", "VG-VQA", "Heron", "MECHA"]
-    
-    # Define desired task order for English tasks
-    en_task_order = ["OK-VQA", "TextVQA", "AI2D", "ChartQA", "DocVQA", "BLINK", "InfoVQA", "MMMU", "LLAVA"]
+    # Task orders derived from metadata
+    ja_task_order = JAPANESE_TASKS
+    en_task_order = ENGLISH_TASKS
     
     # Prepare data for Japanese tasks with specific ordering
     ja_columns_ordered = []

--- a/src/eval_mm/metadata.py
+++ b/src/eval_mm/metadata.py
@@ -29,52 +29,50 @@ class MetricMeta:
 # ── Task metadata ──────────────────────────────────────────────────
 
 TASKS: dict[str, TaskMeta] = {t.task_id: t for t in [
-    # Japanese — visual-centric
-    TaskMeta("japanese-heron-bench", "Heron", "視覚中心",
-             ["heron-bench"], "https://huggingface.co/datasets/turing-motors/Japanese-Heron-Bench"),
-    TaskMeta("ja-vlm-bench-in-the-wild", "JVB-ItW", "視覚中心",
-             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-VLM-Bench-In-the-Wild"),
-    TaskMeta("ja-vg-vqa-500", "VG-VQA", "視覚中心",
-             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-VG-VQA-500"),
-    TaskMeta("jic-vqa", "JIC", "視覚中心",
-             ["jic-vqa"], "https://huggingface.co/datasets/line-corporation/JIC-VQA"),
-    TaskMeta("cvqa", "CVQA", "視覚中心",
-             ["substring-match"], "https://huggingface.co/datasets/afaji/cvqa"),
-    # Japanese — knowledge-centric
-    TaskMeta("jmmmu", "JMMMU", "言語・知識中心",
-             ["jmmmu"], "https://huggingface.co/datasets/JMMMU/JMMMU"),
-    TaskMeta("jdocqa", "JDocQA", "言語・知識中心",
-             ["jdocqa"], "https://github.com/mizuumi/JDocQA"),
-    TaskMeta("mecha-ja", "MECHA", "言語・知識中心",
-             ["mecha-ja"], "https://huggingface.co/datasets/llm-jp/MECHA-ja"),
-    TaskMeta("cc-ocr", "CC-OCR", "言語・知識中心",
-             ["cc-ocr"], "https://huggingface.co/datasets/wulipc/CC-OCR"),
-    # Japanese — other
-    TaskMeta("ja-multi-image-vqa", "MulIm-VQA", "その他",
-             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-Multi-Image-VQA"),
-    # English
+    # English (leaderboard display order)
+    TaskMeta("okvqa", "OK-VQA", "英語",
+             ["substring-match"], ""),
+    TaskMeta("textvqa", "TextVQA", "英語",
+             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/textvqa"),
+    TaskMeta("ai2d", "AI2D", "英語",
+             ["ai2d"], "https://huggingface.co/datasets/lmms-lab/ai2d"),
+    TaskMeta("chartqa", "ChartQA", "英語",
+             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/ChartQA"),
+    TaskMeta("docvqa", "DocVQA", "英語",
+             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/DocVQA"),
+    TaskMeta("blink", "BLINK", "英語",
+             ["blink"], "https://huggingface.co/datasets/BLINK-Benchmark/BLINK"),
+    TaskMeta("infographicvqa", "InfoVQA", "英語",
+             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/infographicvqa"),
     TaskMeta("mmmu", "MMMU", "英語",
              ["mmmu"], "https://huggingface.co/datasets/MMMU/MMMU"),
     TaskMeta("llava-bench-in-the-wild", "LLAVA", "英語",
              ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/lmms-lab/llava-bench-in-the-wild"),
-    TaskMeta("ai2d", "AI2D", "英語",
-             ["ai2d"], "https://huggingface.co/datasets/lmms-lab/ai2d"),
-    TaskMeta("blink", "BLINK", "英語",
-             ["blink"], "https://huggingface.co/datasets/BLINK-Benchmark/BLINK"),
-    TaskMeta("docvqa", "DocVQA", "英語",
-             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/DocVQA"),
-    TaskMeta("infographicvqa", "InfoVQA", "英語",
-             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/infographicvqa"),
-    TaskMeta("textvqa", "TextVQA", "英語",
-             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/textvqa"),
-    TaskMeta("chartqa", "ChartQA", "英語",
-             ["substring-match"], "https://huggingface.co/datasets/lmms-lab/ChartQA"),
     TaskMeta("chartqapro", "ChartQAPro", "英語",
-             ["substring-match"], ""),
-    TaskMeta("okvqa", "OK-VQA", "英語",
              ["substring-match"], ""),
     TaskMeta("mmmlu", "MMMLU", "英語",
              ["exact-match"], ""),
+    # Japanese (leaderboard display order)
+    TaskMeta("cvqa", "CVQA", "視覚中心",
+             ["substring-match"], "https://huggingface.co/datasets/afaji/cvqa"),
+    TaskMeta("cc-ocr", "CC-OCR", "言語・知識中心",
+             ["cc-ocr"], "https://huggingface.co/datasets/wulipc/CC-OCR"),
+    TaskMeta("jic-vqa", "JIC", "視覚中心",
+             ["jic-vqa"], "https://huggingface.co/datasets/line-corporation/JIC-VQA"),
+    TaskMeta("ja-multi-image-vqa", "MulIm-VQA", "その他",
+             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-Multi-Image-VQA"),
+    TaskMeta("jmmmu", "JMMMU", "言語・知識中心",
+             ["jmmmu"], "https://huggingface.co/datasets/JMMMU/JMMMU"),
+    TaskMeta("jdocqa", "JDocQA", "言語・知識中心",
+             ["jdocqa"], "https://github.com/mizuumi/JDocQA"),
+    TaskMeta("ja-vlm-bench-in-the-wild", "JVB-ItW", "視覚中心",
+             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-VLM-Bench-In-the-Wild"),
+    TaskMeta("ja-vg-vqa-500", "VG-VQA", "視覚中心",
+             ["llm-as-a-judge", "rougel"], "https://huggingface.co/datasets/SakanaAI/JA-VG-VQA-500"),
+    TaskMeta("japanese-heron-bench", "Heron", "視覚中心",
+             ["heron-bench"], "https://huggingface.co/datasets/turing-motors/Japanese-Heron-Bench"),
+    TaskMeta("mecha-ja", "MECHA", "言語・知識中心",
+             ["mecha-ja"], "https://huggingface.co/datasets/llm-jp/MECHA-ja"),
 ]}
 
 
@@ -153,6 +151,13 @@ def get_task_alias() -> dict[str, str]:
 def get_task_cluster_alias() -> dict[str, str]:
     """Return {display_name: cluster} mapping."""
     return {t.display_name: t.cluster for t in TASKS.values()}
+
+
+def get_tasks_by_language() -> tuple[list[str], list[str]]:
+    """Return (english_display_names, japanese_display_names) derived from cluster field."""
+    english = [t.display_name for t in TASKS.values() if t.cluster == "英語"]
+    japanese = [t.display_name for t in TASKS.values() if t.cluster != "英語"]
+    return english, japanese
 
 
 def get_metric_alias() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- Added `get_tasks_by_language()` helper to `metadata.py`
- Replaced 4 locations of hardcoded EN/JA task lists in `make_leaderboard.py` with metadata-derived constants
- Reordered TASKS dict to match leaderboard display order

Closes #185

## Test plan
- [x] All existing tests pass
- [x] Task ordering preserved (English first, then Japanese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)