### PR TITLE
refactor: unify scripts/ data loading via result_schema API (#186)

### DIFF
--- a/scripts/browse_prediction.py
+++ b/scripts/browse_prediction.py
@@ -13,7 +13,6 @@ Displays per-sample predictions with:
 - Paging and random jump navigation
 """
 
-import json
 import os
 import random
 from argparse import ArgumentParser
@@ -21,6 +20,7 @@ from argparse import ArgumentParser
 import streamlit as st
 
 import eval_mm
+from eval_mm import load_predictions
 from eval_mm.metadata import TASKS
 
 
@@ -61,14 +61,11 @@ if __name__ == "__main__":
     # Load model predictions
     predictions_per_model = {}
     for model_id in args.model_list:
-        prediction_path = os.path.join(
-            args.result_dir, args.task_id, model_id, "prediction.jsonl"
-        )
-        if not os.path.exists(prediction_path):
+        output_dir = os.path.join(args.result_dir, args.task_id, model_id)
+        if not os.path.isfile(os.path.join(output_dir, "prediction.jsonl")):
             st.warning(f"Predictions not found for {model_id}")
             continue
-        with open(prediction_path, "r") as f:
-            predictions_per_model[model_id] = [json.loads(line) for line in f]
+        predictions_per_model[model_id] = load_predictions(output_dir)
 
     active_models = list(predictions_per_model.keys())
 

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -12,7 +12,6 @@ Provides:
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
@@ -28,6 +27,7 @@ sys.path.insert(0, str(_repo_root / "examples"))
 
 import eval_mm
 import eval_mm.metrics
+from eval_mm import load_evaluation
 from eval_mm.metadata import TASKS, METRICS, LEADERBOARD_MODELS
 
 # ---------------------------------------------------------------------------
@@ -128,13 +128,12 @@ def scan_results(result_dir: str) -> dict[tuple[str, str], list[str]]:
 
 
 def load_evaluation_score(result_dir: str, task_id: str, model_id: str) -> dict | None:
-    """Load evaluation.jsonl for a (task, model) pair."""
-    eval_path = os.path.join(result_dir, task_id, model_id, "evaluation.jsonl")
-    if not os.path.isfile(eval_path):
+    """Load evaluation.jsonl for a (task, model) pair via result_schema API."""
+    output_dir = os.path.join(result_dir, task_id, model_id)
+    if not os.path.isfile(os.path.join(output_dir, "evaluation.jsonl")):
         return None
     try:
-        with open(eval_path) as f:
-            return json.loads(f.readline())
+        return load_evaluation(output_dir)
     except Exception:
         return None
 

--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 from loguru import logger
 import eval_mm
 import eval_mm.metrics
+from eval_mm import load_evaluation
 import seaborn as sns
 import matplotlib.pyplot as plt
 import japanize_matplotlib  # noqa: F401  # enable Japanese fonts in Matplotlib
@@ -29,13 +30,13 @@ def load_evaluation_data(result_dir: str, model: str, task_dirs: list[str]) -> d
     """Load evaluation results for a given model across multiple tasks."""
     model_results = {"Model": model}
     for task_dir in task_dirs:
-        eval_path = os.path.join(result_dir, task_dir, model, "evaluation.jsonl")
+        output_dir = os.path.join(result_dir, task_dir, model)
+        eval_path = os.path.join(output_dir, "evaluation.jsonl")
         if not os.path.exists(eval_path):
             logger.warning(f"{eval_path} not found. Skipping...")
             continue
 
-        with open(eval_path, "r") as f:
-            evaluation = json.load(f)
+        evaluation = load_evaluation(output_dir)
 
         for metric, aggregate_output in evaluation.items():
             if metric not in eval_mm.ScorerRegistry.get_metric_list():


### PR DESCRIPTION
## Summary
- Replaced manual JSON parsing in `browse_prediction.py`, `make_leaderboard.py`, and `dashboard.py` with `eval_mm.result_schema` API calls (`load_predictions`, `load_evaluation`)
- Removed redundant `import json` from scripts that no longer need it
- Kept `load_evaluation_score` wrapper in `dashboard.py` for null-safety but delegated to `load_evaluation` internally

Closes #186

## Test plan
- [x] All existing tests pass (16/16)
- [x] Scripts use unified API for data loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)