### PR TITLE
fix: wire --max_model_len CLI param to vllm_kwargs (#191)

### DIFF
--- a/src/eval_mm/cli.py
+++ b/src/eval_mm/cli.py
@@ -143,6 +143,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     vllm_kwargs = {
         "gpu_memory_utilization": args.gpu_memory_utilization,
         "tensor_parallel_size": args.tensor_parallel_size,
+        "max_model_len": args.max_model_len,
     }
 
     model = _load_model(args.model_id, args.backend, vllm_kwargs)


### PR DESCRIPTION
## Summary
- `--max_model_len` was defined as CLI argument but never forwarded to vLLM kwargs
- Added it to the `vllm_kwargs` dict in `cmd_run()`

Closes #191

## Test plan
- [x] Existing tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)