### PR TITLE
refactor: fix type contract violations (#193)

### DIFF
--- a/src/eval_mm/metrics/scorer.py
+++ b/src/eval_mm/metrics/scorer.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Any
+
 from eval_mm.utils.azure_client import OpenAIChatAPI
 
 
@@ -11,7 +13,7 @@ class AggregateOutput:
 
 @dataclass
 class ScorerConfig:
-    docs: dict | None = None
+    docs: Any = None
     judge_model: str | None = None
     client: OpenAIChatAPI | None = None
     batch_size: int = 10

--- a/src/eval_mm/tasks/task.py
+++ b/src/eval_mm/tasks/task.py
@@ -57,6 +57,6 @@ class Task(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def doc_to_answer(self, doc) -> str:
+    def doc_to_answer(self, doc) -> str | list[str]:
         """Converts a document to answer."""
         pass


### PR DESCRIPTION
## Summary
- `Task.doc_to_answer()` return type changed from `str` to `str | list[str]` to match actual implementations (multiple tasks return lists)
- `ScorerConfig.docs` type changed from `dict | None` to `Any` since it receives `Dataset`, `dict`, and `list[dict]` in practice

Closes #193

## Test plan
- [x] All 16 tests pass (`uv run pytest src/eval_mm/tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)