### PR TITLE
chore: integrity review batch fixes (#194)

### DIFF
--- a/scripts/consistency_mecha_ja.py
+++ b/scripts/consistency_mecha_ja.py
@@ -11,13 +11,13 @@ import numpy as np
 vis_dir = "logs/mecha-ja/visualize/"
 root_dir = "logs/mecha-ja/prediction/"
 files = os.listdir(root_dir)
-model_names = [
+model_ids = [
     os.path.basename(f).replace(".jsonl", "") for f in files if f.endswith(".jsonl")
 ]
 
 model_files = {
-    model_name: os.path.join(root_dir, f"{model_name}.jsonl")
-    for model_name in model_names
+    model_id: os.path.join(root_dir, f"{model_id}.jsonl")
+    for model_id in model_ids
 }
 
 model_dfs = {}
@@ -46,10 +46,10 @@ def check_abcd(text):
     return found[0] if len(found) == 1 else "F"
 
 
-for model_name, file_path in model_files.items():
+for model_id, file_path in model_files.items():
     df = load_jsonl_to_df(file_path)
     df["pred"] = df["text"].apply(check_abcd)
-    model_dfs[model_name] = df
+    model_dfs[model_id] = df
 
 rotate_map = {
     "A": ["A", "D", "C", "B"],
@@ -67,7 +67,7 @@ fig, axes = plt.subplots(nrows=3, ncols=3, figsize=(10, 10), sharex=True, sharey
 # axesを1次元にする
 axes = axes.flatten()
 
-for ax, (model_name, df) in zip(axes, model_dfs.items()):
+for ax, (model_id, df) in zip(axes, model_dfs.items()):
     # 予測回答の分布（相対頻度）をカウント
     pred_counts = (
         df["pred"].value_counts().reindex(["A", "B", "C", "D", "F"], fill_value=0)
@@ -83,7 +83,7 @@ for ax, (model_name, df) in zip(axes, model_dfs.items()):
     # 0.25 に赤い線を引く
     ax.axhline(y=0.25, color="r", linestyle="--", linewidth=1)
 
-    ax.set_title(f"{model_name}")
+    ax.set_title(f"{model_id}")
     ax.set_xlabel("選択肢")
     ax.set_ylabel("選択頻度")
 
@@ -100,7 +100,7 @@ plt.close()
 # ======================================
 results = []
 
-for model_name, df in model_dfs.items():
+for model_id, df in model_dfs.items():
     # soft accuracy
     soft_accuracy = df["mecha-ja"].mean()  # 1と0の平均 = 正解率
 
@@ -140,7 +140,7 @@ for model_name, df in model_dfs.items():
 
     results.append(
         {
-            "model": model_name,
+            "model": model_id,
             "soft_accuracy": soft_accuracy,
             "strict_accuracy": strict_accuracy,
             "consistency": consistency,

--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -26,6 +26,8 @@ TASK_CLUSTER_ALIAS = get_task_cluster_alias()
 METRIC_ALIAS = get_metric_alias()
 MODEL_LIST = LEADERBOARD_MODELS
 ENGLISH_TASKS, JAPANESE_TASKS = get_tasks_by_language()
+ENGLISH_TASKS_SET = set(ENGLISH_TASKS)
+JAPANESE_TASKS_SET = set(JAPANESE_TASKS)
 
 
 def load_evaluation_data(result_dir: str, model: str, task_dirs: list[str]) -> dict:
@@ -148,22 +150,20 @@ def plot_correlation(df: pd.DataFrame, filename: str, tex_columns: list[str] = N
     
     # Define task order as in TeX output: English tasks → Japanese tasks
     task_order = ENGLISH_TASKS + JAPANESE_TASKS
-    english_tasks = set(ENGLISH_TASKS)
-    japanese_tasks = set(JAPANESE_TASKS)
-    
+
     # Filter and reorder dataframe columns based on task_order
     available_tasks = [task for task in task_order if task in df.columns]
     df = df[available_tasks]
-    
+
     corr = df.corr(method="spearman")
-    
+
     # Create a mask for the upper triangle
     mask = np.zeros_like(corr, dtype=bool)
     mask[np.triu_indices_from(mask, k=1)] = True
-    
+
     # Create figure
     fig, ax = plt.subplots(figsize=(12, 10))
-    
+
     # Plot heatmap with lower triangle only
     hm = sns.heatmap(
         corr,
@@ -179,7 +179,7 @@ def plot_correlation(df: pd.DataFrame, filename: str, tex_columns: list[str] = N
         vmin=0,  # Set minimum to 0
         vmax=1,
     )
-    
+
     # Make tick labels bold and larger
     ax.set_xticklabels(ax.get_xmajorticklabels(), fontsize=20, fontweight='bold', rotation=45, ha='right')
     ax.set_yticklabels(ax.get_ymajorticklabels(), fontsize=20, fontweight='bold', rotation=0)
@@ -195,14 +195,14 @@ def plot_correlation(df: pd.DataFrame, filename: str, tex_columns: list[str] = N
 
     # Color Japanese task labels red on both axes
     for tick in ax.get_xticklabels():
-        if tick.get_text() in japanese_tasks:
+        if tick.get_text() in JAPANESE_TASKS_SET:
             tick.set_color('red')
     for tick in ax.get_yticklabels():
-        if tick.get_text() in japanese_tasks:
+        if tick.get_text() in JAPANESE_TASKS_SET:
             tick.set_color('red')
 
     # Add dotted divider between English and Japanese blocks (if both exist)
-    en_count = sum(1 for t in corr.columns if t in english_tasks)
+    en_count = sum(1 for t in corr.columns if t in ENGLISH_TASKS_SET)
     if 0 < en_count < len(corr.columns):
         # Place divider exactly between LLAVA (last EN) and CVQA (first JA) at integer boundary n
         boundary = en_count
@@ -315,30 +315,29 @@ def plot_task_clustering(df: pd.DataFrame, filename: str, tex_columns: list[str]
         rename_dict[col] = task_name
     df = df.rename(columns=rename_dict)
     
-    # Define task order as in TeX output: English tasks → Japanese tasks
+    # Define task order as in TeX output: English tasks -> Japanese tasks
     task_order = ENGLISH_TASKS + JAPANESE_TASKS
-    japanese_tasks = set(JAPANESE_TASKS)
-    
+
     # Filter and reorder dataframe columns based on task_order
     available_tasks = [task for task in task_order if task in df.columns]
     df = df[available_tasks]
-    
+
     # Calculate correlation matrix
     corr = df.corr(method="spearman")
-    
+
     # Convert correlation to distance (1 - correlation)
     # This ensures high correlation = small distance
     distance_matrix = 1 - corr
-    
+
     # Convert to condensed distance matrix
     condensed_distance = squareform(distance_matrix)
-    
+
     # Perform hierarchical clustering
     linkage = sch.linkage(condensed_distance, method='average')
-    
+
     # Create figure
     plt.figure(figsize=(12, 8))
-    
+
     # Plot dendrogram
     dendrogram = sch.dendrogram(
         linkage,
@@ -349,24 +348,24 @@ def plot_task_clustering(df: pd.DataFrame, filename: str, tex_columns: list[str]
         # Increase leaf font size by 4pt
         leaf_font_size=24,
     )
-    
+
     # Increase title/xlabel/ylabel font sizes by 4pt
     plt.title('相関行列に基づくタスク階層クラスタリング', fontsize=32, fontweight='bold')
     plt.xlabel('タスク', fontsize=24, fontweight='bold')
     plt.ylabel('距離（1 - スピアマン相関）', fontsize=24, fontweight='bold')
-    
+
     # Make x-axis labels bold and color Japanese tasks red
     ax = plt.gca()
     # Increase tick label font size by 4pt
     ax.set_xticklabels(ax.get_xmajorticklabels(), fontsize=24, fontweight='bold', rotation=45, ha='right')
     for tick in ax.get_xticklabels():
-        if tick.get_text() in japanese_tasks:
+        if tick.get_text() in JAPANESE_TASKS_SET:
             tick.set_color('red')
-    
+
     plt.tight_layout()
     plt.savefig(filename, dpi=150, bbox_inches='tight')
     plt.close()
-    
+
     # Also create a horizontal dendrogram for better readability
     plt.figure(figsize=(10, 12))
     dendrogram_h = sch.dendrogram(
@@ -386,7 +385,7 @@ def plot_task_clustering(df: pd.DataFrame, filename: str, tex_columns: list[str]
     ax = plt.gca()
     ax.set_yticklabels(ax.get_ymajorticklabels(), fontsize=20, fontweight='bold')
     for tick in ax.get_yticklabels():
-        if tick.get_text() in japanese_tasks:
+        if tick.get_text() in JAPANESE_TASKS_SET:
             tick.set_color('red')
     
     plt.tight_layout()

--- a/src/eval_mm/cli.py
+++ b/src/eval_mm/cli.py
@@ -63,14 +63,14 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         "--task_id",
         default="japanese-heron-bench",
-        help=f"Available: {eval_mm.TaskRegistry().get_task_list()}",
+        help=f"Available: {eval_mm.TaskRegistry.get_task_list()}",
     )
     run_parser.add_argument(
         "--metrics",
         type=str,
         nargs="+",
         default=["heron-bench"],
-        help=f"Available: {eval_mm.ScorerRegistry().get_metric_list()}",
+        help=f"Available: {eval_mm.ScorerRegistry.get_metric_list()}",
     )
     run_parser.add_argument("--judge_model", default="gpt-4o-2024-11-20")
     run_parser.add_argument("--batch_size_for_evaluation", type=int, default=10)
@@ -183,12 +183,12 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
 
 def cmd_list(args: argparse.Namespace) -> None:
     if args.what == "tasks":
-        tasks = eval_mm.TaskRegistry().get_task_list()
+        tasks = eval_mm.TaskRegistry.get_task_list()
         print("Available tasks:")
         for t in sorted(tasks):
             print(f"  - {t}")
     elif args.what == "metrics":
-        metrics = eval_mm.ScorerRegistry().get_metric_list()
+        metrics = eval_mm.ScorerRegistry.get_metric_list()
         print("Available metrics:")
         for m in sorted(metrics):
             print(f"  - {m}")

--- a/src/eval_mm/metrics/__init__.py
+++ b/src/eval_mm/metrics/__init__.py
@@ -3,7 +3,7 @@ from .exact_match_scorer import ExactMatchScorer
 from .llm_as_a_judge_scorer import LlmAsaJudgeScorer
 from .rougel_scorer import RougeLScorer
 from .substring_match_scorer import SubstringMatchScorer
-from .scorer import Scorer
+from .scorer import Scorer, ScorerConfig
 from .jmmmu_scorer import JMMMUScorer
 from .mmmu_scorer import MMMUScorer
 from .jdocqa_scorer import JDocQAScorer
@@ -23,6 +23,7 @@ __all__ = [
     "RougeLScorer",
     "SubstringMatchScorer",
     "Scorer",
+    "ScorerConfig",
     "JMMMUScorer",
     "MMMUScorer",
     "JDocQAScorer",

--- a/src/eval_mm/metrics/heron_bench_scorer.py
+++ b/src/eval_mm/metrics/heron_bench_scorer.py
@@ -1,7 +1,7 @@
-from eval_mm.utils.azure_client import OpenAIChatAPI
+from ..utils.azure_client import OpenAIChatAPI
 from collections import defaultdict
 import numpy as np
-from eval_mm.metrics.scorer import Scorer, AggregateOutput
+from .scorer import Scorer, AggregateOutput
 from .scorer_registry import register_scorer
 import re
 import json

--- a/src/eval_mm/metrics/jdocqa_scorer.py
+++ b/src/eval_mm/metrics/jdocqa_scorer.py
@@ -1,4 +1,4 @@
-from eval_mm.metrics.scorer import Scorer, AggregateOutput
+from .scorer import Scorer, AggregateOutput
 from .scorer_registry import register_scorer
 from sacrebleu import sentence_bleu
 from unicodedata import normalize

--- a/src/eval_mm/metrics/jmmmu_scorer.py
+++ b/src/eval_mm/metrics/jmmmu_scorer.py
@@ -3,7 +3,7 @@ import ast
 import re
 import numpy as np
 from datasets import Dataset
-from eval_mm.metrics.scorer import Scorer, AggregateOutput
+from .scorer import Scorer, AggregateOutput
 from .scorer_registry import register_scorer
 
 

--- a/src/eval_mm/metrics/llm_as_a_judge_scorer.py
+++ b/src/eval_mm/metrics/llm_as_a_judge_scorer.py
@@ -1,4 +1,4 @@
-from eval_mm.metrics.scorer import Scorer, AggregateOutput
+from .scorer import Scorer, AggregateOutput
 from .scorer_registry import register_scorer
 from tqdm import tqdm
 import re

--- a/src/eval_mm/metrics/scorer.py
+++ b/src/eval_mm/metrics/scorer.py
@@ -25,9 +25,9 @@ class Scorer(ABC):
         self.config = config
 
     @abstractmethod
-    def score(self, refs: list[str], preds: list[str]) -> list:
-        raise NotImplementedError
+    def score(self, refs: list[str], preds: list[str]) -> list[int | float | dict]:
+        ...
 
     @abstractmethod
-    def aggregate(self, scores: list) -> AggregateOutput:
-        raise NotImplementedError
+    def aggregate(self, scores: list[int | float | dict]) -> AggregateOutput:
+        ...

--- a/src/eval_mm/models/base_vlm.py
+++ b/src/eval_mm/models/base_vlm.py
@@ -1,11 +1,15 @@
+from abc import ABC, abstractmethod
+
 from PIL import Image
 from .generation_config import GenerationConfig
 
 
-class BaseVLM:
+class BaseVLM(ABC):
+    @abstractmethod
     def __init__(self):
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def generate(
         self,
         images: list[Image.Image] | None,
@@ -13,8 +17,9 @@ class BaseVLM:
         gen_kwargs: GenerationConfig = GenerationConfig(),
     ) -> str:
         """Generate a response given an image (or list of images) and a prompt."""
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def batch_generate(
         self,
         images_list: list[list[Image.Image]] | None,
@@ -22,4 +27,4 @@ class BaseVLM:
         gen_kwargs: GenerationConfig = GenerationConfig(),
     ) -> list[str]:
         """Generate a response given a list of images and a list of prompts."""
-        raise NotImplementedError
+        ...

--- a/src/eval_mm/tasks/__init__.py
+++ b/src/eval_mm/tasks/__init__.py
@@ -19,6 +19,7 @@ from .textvqa import TextVQA
 from .chartqa import ChartQA
 from .chartqapro import ChartQAPro
 from .okvqa import OKVQA
+from .mnist import MNIST
 from .task_registry import TaskRegistry
 from .task import TaskConfig
 
@@ -44,6 +45,7 @@ __all__ = [
     "ChartQA",
     "ChartQAPro",
     "OKVQA",
+    "MNIST",
     "TaskRegistry",
     "TaskConfig",
 ]

--- a/src/eval_mm/tests/test_smoke.py
+++ b/src/eval_mm/tests/test_smoke.py
@@ -68,8 +68,8 @@ def test_generation_config_custom():
 # ── BaseVLM tests ───────────────────────────────────────────────────
 
 
-def test_base_vlm_raises_not_implemented():
-    with pytest.raises(NotImplementedError):
+def test_base_vlm_is_abstract():
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
         BaseVLM()
 
 


### PR DESCRIPTION
## Summary
- BaseVLM now uses ABC + @abstractmethod instead of manual NotImplementedError
- Scorer.score() return type made explicit (`list[int | float | dict]`)
- MNIST exported in tasks/__init__.py, ScorerConfig in metrics/__init__.py
- Standardized relative imports in 4 scorer files (heron_bench, jdocqa, jmmmu, llm_as_a_judge)
- Renamed model_name -> model_id in consistency_mecha_ja.py
- Removed unnecessary Registry() instantiation in cli.py (classmethods don't need instances)
- Module-level ENGLISH_TASKS_SET/JAPANESE_TASKS_SET in make_leaderboard.py
- Updated test to match ABC pattern (TypeError instead of NotImplementedError)

Refs #194

## Test plan
- [x] All 16 tests pass (`uv run pytest src/eval_mm/tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)