### PR TITLE
fix: forward max_model_len through runner to VLLM (#199)

### DIFF
--- a/examples/base_vllm.py
+++ b/examples/base_vllm.py
@@ -16,6 +16,7 @@ class VLLM(BaseVLM):
         model_id: str,
         gpu_memory_utilization: float = 0.8,
         tensor_parallel_size: int = 1,
+        max_model_len: int | None = None,
     ) -> None:
         self.registry = VLLMModelRegistry(model_id)
 
@@ -23,6 +24,8 @@ class VLLM(BaseVLM):
             "tensor_parallel_size": tensor_parallel_size,
             "gpu_memory_utilization": gpu_memory_utilization,
         }
+        if max_model_len is not None:
+            engine_args["max_model_len"] = max_model_len
 
         self.model_id = model_id
         self.model = LLM(**engine_args)

--- a/src/eval_mm/cli.py
+++ b/src/eval_mm/cli.py
@@ -43,6 +43,7 @@ def _load_model(model_id: str, backend: str, vllm_kwargs: dict):
             model_id=model_id,
             gpu_memory_utilization=vllm_kwargs.get("gpu_memory_utilization", 0.95),
             tensor_parallel_size=vllm_kwargs.get("tensor_parallel_size", 1),
+            max_model_len=vllm_kwargs.get("max_model_len"),
         )
     else:
         model_table = importlib.import_module("model_table")


### PR DESCRIPTION
## Summary
- Added `max_model_len` parameter to VLLM constructor in `examples/base_vllm.py`
- `_load_model()` in `cli.py` now extracts and forwards `max_model_len` from `vllm_kwargs`

Closes #199

## Test plan
- [x] All 16 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)