### PR TITLE
feat: Leaderboard with Stripe-inspired data table (#203)

### DIFF
--- a/web/src/app/leaderboard/page.tsx
+++ b/web/src/app/leaderboard/page.tsx
@@ -1,17 +1,32 @@
+import { LEADERBOARD_DATA, TASKS, LAST_UPDATED } from "@/lib/mock-data";
+import { StatsSummary } from "@/components/stats-summary";
+import { LeaderboardTable } from "@/components/leaderboard-table";
+
 export default function LeaderboardPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold tracking-tight">Leaderboard</h1>
-      <p className="mt-2 text-muted-foreground">
-        Compare model performance across tasks and metrics.
-      </p>
-
-      <div className="mt-8 rounded-lg border bg-card p-6 text-card-foreground">
-        <p className="text-sm text-muted-foreground">
-          Leaderboard coming soon. This page will show sortable tables and
-          visualisations of evaluation scores across models and benchmarks.
+    <div className="mx-auto max-w-[1600px] px-4 py-10 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-[#061b31]">
+          Leaderboard
+        </h1>
+        <p className="mt-2 text-sm text-[#64748d]">
+          Compare model performance across English and Japanese multimodal
+          benchmarks.
         </p>
       </div>
+
+      {/* Stats cards */}
+      <div className="mb-8">
+        <StatsSummary
+          modelCount={LEADERBOARD_DATA.length}
+          taskCount={TASKS.length}
+          lastUpdated={LAST_UPDATED}
+        />
+      </div>
+
+      {/* Leaderboard table */}
+      <LeaderboardTable data={LEADERBOARD_DATA} />
     </div>
   );
 }

--- a/web/src/components/leaderboard-table.tsx
+++ b/web/src/components/leaderboard-table.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  type ModelEntry,
+  type TaskDef,
+  EN_TASKS,
+  JA_TASKS,
+} from "@/lib/mock-data";
+import { cn } from "@/lib/utils";
+import { ArrowUp, ArrowDown, ArrowUpDown } from "lucide-react";
+
+// ── Types ────────────────────────────────────────────────────────
+
+type SortKey = "displayName" | "overall" | "enAvg" | "jaAvg" | string;
+type SortDir = "asc" | "desc";
+
+interface LeaderboardTableProps {
+  data: ModelEntry[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** For a given column (by task displayName), find indices of top-1 and top-2 scores. */
+function getTopIndices(
+  rows: ModelEntry[],
+  key: string,
+): { top1: number; top2: number } {
+  let top1 = -1;
+  let top2 = -1;
+  let max1 = -Infinity;
+  let max2 = -Infinity;
+
+  rows.forEach((row, i) => {
+    const val =
+      key === "overall"
+        ? row.overall
+        : key === "enAvg"
+          ? row.enAvg
+          : key === "jaAvg"
+            ? row.jaAvg
+            : row.scores[key];
+    if (val == null) return;
+    if (val > max1) {
+      max2 = max1;
+      top2 = top1;
+      max1 = val;
+      top1 = i;
+    } else if (val > max2) {
+      max2 = val;
+      top2 = i;
+    }
+  });
+
+  return { top1, top2 };
+}
+
+// ── Sort icon ────────────────────────────────────────────────────
+
+function SortIcon({
+  column,
+  sortKey,
+  sortDir,
+}: {
+  column: string;
+  sortKey: SortKey;
+  sortDir: SortDir;
+}) {
+  if (sortKey !== column) {
+    return <ArrowUpDown className="ml-1 inline size-3 opacity-30" />;
+  }
+  return sortDir === "asc" ? (
+    <ArrowUp className="ml-1 inline size-3" />
+  ) : (
+    <ArrowDown className="ml-1 inline size-3" />
+  );
+}
+
+// ── Cluster header ───────────────────────────────────────────────
+
+function ClusterHeader({
+  label,
+  span,
+}: {
+  label: string;
+  span: number;
+}) {
+  return (
+    <th
+      colSpan={span}
+      className="border-b border-[#e5edf5] bg-[#f8fafc] px-2 py-1.5 text-center text-xs font-semibold tracking-wide text-[#64748d]"
+    >
+      {label}
+    </th>
+  );
+}
+
+// ── Score cell ───────────────────────────────────────────────────
+
+function ScoreCell({
+  value,
+  isTop1,
+  isTop2,
+}: {
+  value: number | null;
+  isTop1: boolean;
+  isTop2: boolean;
+}) {
+  if (value == null) {
+    return (
+      <TableCell className="text-center text-[#64748d]/50">--</TableCell>
+    );
+  }
+  return (
+    <TableCell
+      className={cn(
+        "text-center tabular-nums text-[#061b31]",
+        isTop1 && "font-bold",
+        isTop2 && !isTop1 && "underline decoration-[#533afd]/40 underline-offset-2",
+      )}
+    >
+      {value.toFixed(1)}
+    </TableCell>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────
+
+export function LeaderboardTable({ data }: LeaderboardTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("overall");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const handleSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortKey(key);
+        setSortDir("desc");
+      }
+    },
+    [sortKey],
+  );
+
+  const sorted = useMemo(() => {
+    const rows = [...data];
+    rows.sort((a, b) => {
+      let va: number | null;
+      let vb: number | null;
+
+      if (sortKey === "displayName") {
+        const cmp = a.displayName.localeCompare(b.displayName);
+        return sortDir === "asc" ? cmp : -cmp;
+      }
+
+      if (sortKey === "overall") {
+        va = a.overall;
+        vb = b.overall;
+      } else if (sortKey === "enAvg") {
+        va = a.enAvg;
+        vb = b.enAvg;
+      } else if (sortKey === "jaAvg") {
+        va = a.jaAvg;
+        vb = b.jaAvg;
+      } else {
+        va = a.scores[sortKey] ?? null;
+        vb = b.scores[sortKey] ?? null;
+      }
+
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1;
+      if (vb == null) return -1;
+      return sortDir === "asc" ? va - vb : vb - va;
+    });
+    return rows;
+  }, [data, sortKey, sortDir]);
+
+  // Precompute top-1/top-2 per column
+  const aggregateKeys = ["overall", "enAvg", "jaAvg"] as const;
+  const allTaskNames = [...EN_TASKS, ...JA_TASKS].map((t) => t.displayName);
+  const allKeys = [...aggregateKeys, ...allTaskNames];
+
+  const topMap = useMemo(() => {
+    const map: Record<string, { top1: number; top2: number }> = {};
+    for (const key of allKeys) {
+      map[key] = getTopIndices(sorted, key);
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sorted]);
+
+  // ── Column header helper ─────────────────────────────────────
+
+  function SortableHead({
+    column,
+    label,
+    className,
+  }: {
+    column: SortKey;
+    label: string;
+    className?: string;
+  }) {
+    return (
+      <TableHead
+        className={cn(
+          "cursor-pointer select-none border-[#e5edf5] px-3 text-center text-xs font-semibold text-[#061b31] transition-colors hover:bg-[#f0f4fa]",
+          className,
+        )}
+        onClick={() => handleSort(column)}
+      >
+        {label}
+        <SortIcon column={column} sortKey={sortKey} sortDir={sortDir} />
+      </TableHead>
+    );
+  }
+
+  // ── Task column group renderer ───────────────────────────────
+
+  function renderTaskHeaders(tasks: TaskDef[]) {
+    return tasks.map((t) => (
+      <SortableHead key={t.taskId} column={t.displayName} label={t.displayName} />
+    ));
+  }
+
+  function renderTaskCells(row: ModelEntry, rowIdx: number, tasks: TaskDef[]) {
+    return tasks.map((t) => {
+      const tops = topMap[t.displayName];
+      return (
+        <ScoreCell
+          key={t.taskId}
+          value={row.scores[t.displayName] ?? null}
+          isTop1={tops?.top1 === rowIdx}
+          isTop2={tops?.top2 === rowIdx}
+        />
+      );
+    });
+  }
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-[#e5edf5]"
+      style={{ boxShadow: "0 4px 24px rgba(50,50,93,0.08), 0 1px 3px rgba(0,0,0,0.04)" }}
+    >
+      <div className="overflow-x-auto">
+        <Table className="min-w-[1400px]">
+          {/* ── Cluster row ─────────────────────────────────── */}
+          <thead>
+            <tr>
+              {/* Sticky model column + 3 aggregate columns */}
+              <th
+                colSpan={4}
+                className="border-b border-[#e5edf5] bg-white px-2 py-1.5"
+              />
+              <ClusterHeader label="English" span={EN_TASKS.length} />
+              <ClusterHeader label="Japanese" span={JA_TASKS.length} />
+            </tr>
+          </thead>
+
+          {/* ── Sort headers ────────────────────────────────── */}
+          <TableHeader className="bg-white">
+            <TableRow className="border-[#e5edf5] hover:bg-transparent">
+              <TableHead
+                className="sticky left-0 z-10 min-w-[180px] cursor-pointer select-none border-r border-[#e5edf5] bg-white px-4 text-left text-xs font-semibold text-[#061b31] transition-colors hover:bg-[#f0f4fa]"
+                onClick={() => handleSort("displayName")}
+              >
+                Model
+                <SortIcon
+                  column="displayName"
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                />
+              </TableHead>
+              <SortableHead
+                column="overall"
+                label="Overall"
+                className="bg-[#f8f6ff] font-bold"
+              />
+              <SortableHead column="enAvg" label="EN Avg" />
+              <SortableHead column="jaAvg" label="JA Avg" />
+              {renderTaskHeaders(EN_TASKS)}
+              {renderTaskHeaders(JA_TASKS)}
+            </TableRow>
+          </TableHeader>
+
+          {/* ── Body ────────────────────────────────────────── */}
+          <TableBody>
+            {sorted.map((row, rowIdx) => (
+              <TableRow
+                key={row.modelId}
+                className="border-[#e5edf5] transition-colors hover:bg-[#f8f6ff]/60"
+              >
+                {/* Sticky model name */}
+                <TableCell className="sticky left-0 z-10 border-r border-[#e5edf5] bg-white px-4 font-medium text-[#061b31] group-hover/row:bg-[#f8f6ff]/60">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs tabular-nums text-[#64748d]">
+                      {rowIdx + 1}
+                    </span>
+                    <span>{row.displayName}</span>
+                  </div>
+                </TableCell>
+
+                {/* Aggregate columns */}
+                <ScoreCell
+                  value={row.overall}
+                  isTop1={topMap["overall"]?.top1 === rowIdx}
+                  isTop2={topMap["overall"]?.top2 === rowIdx}
+                />
+                <ScoreCell
+                  value={row.enAvg}
+                  isTop1={topMap["enAvg"]?.top1 === rowIdx}
+                  isTop2={topMap["enAvg"]?.top2 === rowIdx}
+                />
+                <ScoreCell
+                  value={row.jaAvg}
+                  isTop1={topMap["jaAvg"]?.top1 === rowIdx}
+                  isTop2={topMap["jaAvg"]?.top2 === rowIdx}
+                />
+
+                {/* Task columns */}
+                {renderTaskCells(row, rowIdx, EN_TASKS)}
+                {renderTaskCells(row, rowIdx, JA_TASKS)}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/leaderboard-table.tsx
+++ b/web/src/components/leaderboard-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -14,9 +14,11 @@ import {
   type TaskDef,
   EN_TASKS,
   JA_TASKS,
+  makeEntryFromScores,
 } from "@/lib/mock-data";
+import { fetchTasks, fetchAllScores, type ApiTask } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { ArrowUp, ArrowDown, ArrowUpDown } from "lucide-react";
+import { ArrowUp, ArrowDown, ArrowUpDown, Loader2 } from "lucide-react";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -25,6 +27,8 @@ type SortDir = "asc" | "desc";
 
 interface LeaderboardTableProps {
   data: ModelEntry[];
+  /** Callback to notify parent of live stats when API data loads. */
+  onApiLoaded?: (info: { modelCount: number; taskCount: number }) => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -134,9 +138,92 @@ function ScoreCell({
 
 // ── Main component ───────────────────────────────────────────────
 
-export function LeaderboardTable({ data }: LeaderboardTableProps) {
+export function LeaderboardTable({ data, onApiLoaded }: LeaderboardTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>("overall");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [apiData, setApiData] = useState<ModelEntry[] | null>(null);
+  const [apiTasks, setApiTasks] = useState<{ en: TaskDef[]; ja: TaskDef[] } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadFromApi() {
+      try {
+        const [tasks, allScores] = await Promise.all([
+          fetchTasks(),
+          fetchAllScores(),
+        ]);
+
+        if (cancelled) return;
+
+        // Build task definitions from API
+        const apiTaskDefs: TaskDef[] = tasks.map((t: ApiTask) => ({
+          taskId: t.task_id,
+          displayName: t.display_name,
+          cluster: t.cluster,
+        }));
+        const enTasks = apiTaskDefs.filter((t) => t.cluster === "英語");
+        const jaTasks = apiTaskDefs.filter((t) => t.cluster !== "英語");
+
+        // Build a map: model_id -> { taskDisplayName -> score }
+        const modelScores: Record<string, Record<string, number | null>> = {};
+        const taskDisplayMap: Record<string, string> = {};
+        for (const t of apiTaskDefs) {
+          taskDisplayMap[t.taskId] = t.displayName;
+        }
+
+        for (const [taskId, entries] of Object.entries(allScores)) {
+          const displayName = taskDisplayMap[taskId];
+          if (!displayName) continue;
+          for (const entry of entries) {
+            if (!modelScores[entry.model_id]) {
+              modelScores[entry.model_id] = {};
+            }
+            // Take the first metric value as the score
+            if (entry.metrics && entry.metrics.length > 0) {
+              const firstMetric = entry.metrics[0];
+              const val = typeof firstMetric === "object"
+                ? Object.values(firstMetric)[0]
+                : firstMetric;
+              if (typeof val === "number") {
+                modelScores[entry.model_id][displayName] = val;
+              }
+            }
+          }
+        }
+
+        // Convert to ModelEntry[]
+        const entries: ModelEntry[] = Object.entries(modelScores).map(
+          ([modelId, scores]) => {
+            const shortName = modelId.includes("/")
+              ? modelId.split("/").pop()!
+              : modelId;
+            return makeEntryFromScores(modelId, shortName, scores, enTasks, jaTasks);
+          },
+        );
+
+        if (entries.length > 0 && !cancelled) {
+          setApiData(entries);
+          setApiTasks({ en: enTasks, ja: jaTasks });
+          onApiLoaded?.({ modelCount: entries.length, taskCount: apiTaskDefs.length });
+        }
+      } catch {
+        // API unavailable — fall back to mock data silently
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadFromApi();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Resolve active data: prefer API data, fall back to props (mock)
+  const activeData = apiData ?? data;
+  const activeEnTasks = apiTasks?.en ?? EN_TASKS;
+  const activeJaTasks = apiTasks?.ja ?? JA_TASKS;
 
   const handleSort = useCallback(
     (key: SortKey) => {
@@ -151,7 +238,7 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
   );
 
   const sorted = useMemo(() => {
-    const rows = [...data];
+    const rows = [...activeData];
     rows.sort((a, b) => {
       let va: number | null;
       let vb: number | null;
@@ -181,11 +268,11 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
       return sortDir === "asc" ? va - vb : vb - va;
     });
     return rows;
-  }, [data, sortKey, sortDir]);
+  }, [activeData, sortKey, sortDir]);
 
   // Precompute top-1/top-2 per column
   const aggregateKeys = ["overall", "enAvg", "jaAvg"] as const;
-  const allTaskNames = [...EN_TASKS, ...JA_TASKS].map((t) => t.displayName);
+  const allTaskNames = [...activeEnTasks, ...activeJaTasks].map((t) => t.displayName);
   const allKeys = [...aggregateKeys, ...allTaskNames];
 
   const topMap = useMemo(() => {
@@ -244,11 +331,31 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
     });
   }
 
+  // ── Loading state ────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-xl border border-[#e5edf5] py-20"
+        style={{ boxShadow: "0 4px 24px rgba(50,50,93,0.08), 0 1px 3px rgba(0,0,0,0.04)" }}
+      >
+        <Loader2 className="mr-2 size-5 animate-spin text-[#533afd]" />
+        <span className="text-sm text-[#64748d]">Loading leaderboard data...</span>
+      </div>
+    );
+  }
+
   return (
     <div
       className="overflow-hidden rounded-xl border border-[#e5edf5]"
       style={{ boxShadow: "0 4px 24px rgba(50,50,93,0.08), 0 1px 3px rgba(0,0,0,0.04)" }}
     >
+      {/* Data source indicator */}
+      {apiData && (
+        <div className="border-b border-[#e5edf5] bg-[#f8f6ff] px-4 py-1.5">
+          <span className="text-xs text-[#533afd]">Live data from API</span>
+        </div>
+      )}
       <div className="overflow-x-auto">
         <Table className="min-w-[1400px]">
           {/* ── Cluster row ─────────────────────────────────── */}
@@ -259,8 +366,8 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
                 colSpan={4}
                 className="border-b border-[#e5edf5] bg-white px-2 py-1.5"
               />
-              <ClusterHeader label="English" span={EN_TASKS.length} />
-              <ClusterHeader label="Japanese" span={JA_TASKS.length} />
+              <ClusterHeader label="English" span={activeEnTasks.length} />
+              <ClusterHeader label="Japanese" span={activeJaTasks.length} />
             </tr>
           </thead>
 
@@ -285,8 +392,8 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
               />
               <SortableHead column="enAvg" label="EN Avg" />
               <SortableHead column="jaAvg" label="JA Avg" />
-              {renderTaskHeaders(EN_TASKS)}
-              {renderTaskHeaders(JA_TASKS)}
+              {renderTaskHeaders(activeEnTasks)}
+              {renderTaskHeaders(activeJaTasks)}
             </TableRow>
           </TableHeader>
 
@@ -325,8 +432,8 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
                 />
 
                 {/* Task columns */}
-                {renderTaskCells(row, rowIdx, EN_TASKS)}
-                {renderTaskCells(row, rowIdx, JA_TASKS)}
+                {renderTaskCells(row, rowIdx, activeEnTasks)}
+                {renderTaskCells(row, rowIdx, activeJaTasks)}
               </TableRow>
             ))}
           </TableBody>

--- a/web/src/components/stats-summary.tsx
+++ b/web/src/components/stats-summary.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { BarChart3, Layers, CalendarDays } from "lucide-react";
+
+interface StatsSummaryProps {
+  modelCount: number;
+  taskCount: number;
+  lastUpdated: string;
+}
+
+const stats = (props: StatsSummaryProps) => [
+  {
+    label: "Models",
+    value: props.modelCount,
+    icon: BarChart3,
+    description: "Evaluated models",
+  },
+  {
+    label: "Tasks",
+    value: props.taskCount,
+    icon: Layers,
+    description: "Benchmark tasks",
+  },
+  {
+    label: "Last Updated",
+    value: props.lastUpdated,
+    icon: CalendarDays,
+    description: "Latest evaluation run",
+  },
+];
+
+export function StatsSummary(props: StatsSummaryProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {stats(props).map((stat) => (
+        <Card
+          key={stat.label}
+          className="border-[#e5edf5] bg-white"
+          style={{
+            boxShadow:
+              "0 2px 12px rgba(50,50,93,0.06), 0 1px 3px rgba(0,0,0,0.03)",
+          }}
+        >
+          <CardContent className="flex items-center gap-4">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[#f8f6ff]">
+              <stat.icon className="size-5 text-[#533afd]" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold tabular-nums text-[#061b31]">
+                {stat.value}
+              </p>
+              <p className="text-xs text-[#64748d]">{stat.description}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/stats-summary.tsx
+++ b/web/src/components/stats-summary.tsx
@@ -1,37 +1,78 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { BarChart3, Layers, CalendarDays } from "lucide-react";
+"use client";
 
-interface StatsSummaryProps {
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { BarChart3, Layers, CalendarDays, Wifi } from "lucide-react";
+import { fetchTasks, fetchModels } from "@/lib/api";
+
+export interface StatsSummaryProps {
   modelCount: number;
   taskCount: number;
   lastUpdated: string;
+  /** Override counts from API (set by LeaderboardTable callback). */
+  apiModelCount?: number;
+  apiTaskCount?: number;
 }
 
-const stats = (props: StatsSummaryProps) => [
-  {
-    label: "Models",
-    value: props.modelCount,
-    icon: BarChart3,
-    description: "Evaluated models",
-  },
-  {
-    label: "Tasks",
-    value: props.taskCount,
-    icon: Layers,
-    description: "Benchmark tasks",
-  },
-  {
-    label: "Last Updated",
-    value: props.lastUpdated,
-    icon: CalendarDays,
-    description: "Latest evaluation run",
-  },
-];
+interface StatItem {
+  label: string;
+  value: number | string;
+  icon: React.ComponentType<{ className?: string }>;
+  description: string;
+}
+
+function buildStats(props: StatsSummaryProps, live: { models: number; tasks: number } | null): StatItem[] {
+  return [
+    {
+      label: "Models",
+      value: live?.models ?? props.apiModelCount ?? props.modelCount,
+      icon: BarChart3,
+      description: live ? "Evaluated models (live)" : "Evaluated models",
+    },
+    {
+      label: "Tasks",
+      value: live?.tasks ?? props.apiTaskCount ?? props.taskCount,
+      icon: Layers,
+      description: live ? "Benchmark tasks (live)" : "Benchmark tasks",
+    },
+    {
+      label: "Last Updated",
+      value: props.lastUpdated,
+      icon: CalendarDays,
+      description: "Latest evaluation run",
+    },
+  ];
+}
 
 export function StatsSummary(props: StatsSummaryProps) {
+  const [liveStats, setLiveStats] = useState<{ models: number; tasks: number } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStats() {
+      try {
+        const [tasks, models] = await Promise.all([
+          fetchTasks(),
+          fetchModels(),
+        ]);
+        if (!cancelled) {
+          setLiveStats({ models: models.length, tasks: tasks.length });
+        }
+      } catch {
+        // API unavailable — keep mock values
+      }
+    }
+
+    loadStats();
+    return () => { cancelled = true; };
+  }, []);
+
+  const items = buildStats(props, liveStats);
+
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-      {stats(props).map((stat) => (
+      {items.map((stat) => (
         <Card
           key={stat.label}
           className="border-[#e5edf5] bg-white"
@@ -48,7 +89,12 @@ export function StatsSummary(props: StatsSummaryProps) {
               <p className="text-2xl font-bold tabular-nums text-[#061b31]">
                 {stat.value}
               </p>
-              <p className="text-xs text-[#64748d]">{stat.description}</p>
+              <p className="text-xs text-[#64748d]">
+                {stat.description}
+                {liveStats && stat.label !== "Last Updated" && (
+                  <Wifi className="ml-1 inline size-3 text-[#533afd]" />
+                )}
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -37,3 +37,33 @@ export async function fetchResults(): Promise<ApiResult[]> {
   if (!res.ok) throw new Error(`Failed to fetch results: ${res.status}`);
   return res.json();
 }
+
+export interface ApiScoreEntry {
+  model_id: string;
+  metrics: Record<string, number>[];
+}
+
+export interface ApiScoresResponse {
+  task_id: string;
+  models: ApiScoreEntry[];
+}
+
+export async function fetchScores(taskId: string): Promise<ApiScoresResponse> {
+  const res = await fetch(`${API_BASE}/api/scores/${taskId}`);
+  if (!res.ok) throw new Error(`Failed to fetch scores for ${taskId}: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchAllScores(): Promise<Record<string, ApiScoreEntry[]>> {
+  const tasks = await fetchTasks();
+  const scores: Record<string, ApiScoreEntry[]> = {};
+  for (const task of tasks) {
+    try {
+      const resp = await fetchScores(task.task_id);
+      scores[task.task_id] = resp.models;
+    } catch {
+      /* skip unavailable tasks */
+    }
+  }
+  return scores;
+}

--- a/web/src/lib/mock-data.ts
+++ b/web/src/lib/mock-data.ts
@@ -93,6 +93,30 @@ function makeEntry(
   };
 }
 
+/**
+ * Build a ModelEntry from arbitrary task lists (used when API provides
+ * different tasks than the hardcoded mock definitions).
+ */
+export function makeEntryFromScores(
+  modelId: string,
+  displayName: string,
+  scores: Record<string, number | null>,
+  enTasks: TaskDef[],
+  jaTasks: TaskDef[],
+): ModelEntry {
+  const enScores = enTasks.map((t) => scores[t.displayName] ?? null);
+  const jaScores = jaTasks.map((t) => scores[t.displayName] ?? null);
+  const allScores = [...enScores, ...jaScores];
+  return {
+    modelId,
+    displayName,
+    scores,
+    overall: avg(allScores),
+    enAvg: avg(enScores),
+    jaAvg: avg(jaScores),
+  };
+}
+
 // ── Mock data ───────────────────────────────────────────────────
 
 export const LEADERBOARD_DATA: ModelEntry[] = [

--- a/web/src/lib/mock-data.ts
+++ b/web/src/lib/mock-data.ts
@@ -1,0 +1,183 @@
+/**
+ * Mock leaderboard data for development.
+ *
+ * Structure mirrors the metadata.py definitions: tasks are grouped by
+ * cluster (英語 = English, others = Japanese-centric), and each model
+ * entry carries per-task scores keyed by display_name.
+ */
+
+// ── Task definitions (mirrors metadata.py) ──────────────────────
+
+export interface TaskDef {
+  taskId: string;
+  displayName: string;
+  cluster: string;
+}
+
+export const TASKS: TaskDef[] = [
+  // English
+  { taskId: "okvqa", displayName: "OK-VQA", cluster: "英語" },
+  { taskId: "textvqa", displayName: "TextVQA", cluster: "英語" },
+  { taskId: "ai2d", displayName: "AI2D", cluster: "英語" },
+  { taskId: "chartqa", displayName: "ChartQA", cluster: "英語" },
+  { taskId: "docvqa", displayName: "DocVQA", cluster: "英語" },
+  { taskId: "blink", displayName: "BLINK", cluster: "英語" },
+  { taskId: "infographicvqa", displayName: "InfoVQA", cluster: "英語" },
+  { taskId: "mmmu", displayName: "MMMU", cluster: "英語" },
+  { taskId: "llava-bench-in-the-wild", displayName: "LLAVA", cluster: "英語" },
+  { taskId: "chartqapro", displayName: "ChartQAPro", cluster: "英語" },
+  { taskId: "mmmlu", displayName: "MMMLU", cluster: "英語" },
+  // Japanese-centric
+  { taskId: "cvqa", displayName: "CVQA", cluster: "視覚中心" },
+  { taskId: "cc-ocr", displayName: "CC-OCR", cluster: "言語・知識中心" },
+  { taskId: "jic-vqa", displayName: "JIC", cluster: "視覚中心" },
+  {
+    taskId: "ja-multi-image-vqa",
+    displayName: "MulIm-VQA",
+    cluster: "その他",
+  },
+  { taskId: "jmmmu", displayName: "JMMMU", cluster: "言語・知識中心" },
+  { taskId: "jdocqa", displayName: "JDocQA", cluster: "言語・知識中心" },
+  {
+    taskId: "ja-vlm-bench-in-the-wild",
+    displayName: "JVB-ItW",
+    cluster: "視覚中心",
+  },
+  { taskId: "ja-vg-vqa-500", displayName: "VG-VQA", cluster: "視覚中心" },
+  {
+    taskId: "japanese-heron-bench",
+    displayName: "Heron",
+    cluster: "視覚中心",
+  },
+  { taskId: "mecha-ja", displayName: "MECHA", cluster: "言語・知識中心" },
+];
+
+export const EN_TASKS = TASKS.filter((t) => t.cluster === "英語");
+export const JA_TASKS = TASKS.filter((t) => t.cluster !== "英語");
+
+// ── Model entry ─────────────────────────────────────────────────
+
+export interface ModelEntry {
+  modelId: string;
+  displayName: string;
+  /** Per-task scores keyed by TaskDef.displayName. null = not evaluated. */
+  scores: Record<string, number | null>;
+  /** Aggregate scores computed from per-task values. */
+  overall: number;
+  enAvg: number;
+  jaAvg: number;
+}
+
+// Helper: compute average of non-null values
+function avg(vals: (number | null)[]): number {
+  const valid = vals.filter((v): v is number => v !== null);
+  if (valid.length === 0) return 0;
+  return Math.round((valid.reduce((a, b) => a + b, 0) / valid.length) * 10) / 10;
+}
+
+function makeEntry(
+  modelId: string,
+  displayName: string,
+  scores: Record<string, number | null>,
+): ModelEntry {
+  const enScores = EN_TASKS.map((t) => scores[t.displayName] ?? null);
+  const jaScores = JA_TASKS.map((t) => scores[t.displayName] ?? null);
+  const allScores = [...enScores, ...jaScores];
+  return {
+    modelId,
+    displayName,
+    scores,
+    overall: avg(allScores),
+    enAvg: avg(enScores),
+    jaAvg: avg(jaScores),
+  };
+}
+
+// ── Mock data ───────────────────────────────────────────────────
+
+export const LEADERBOARD_DATA: ModelEntry[] = [
+  makeEntry("Qwen/Qwen2.5-VL-72B-Instruct", "Qwen2.5-VL-72B", {
+    "OK-VQA": 68.3, "TextVQA": 84.1, "AI2D": 88.5, "ChartQA": 86.2,
+    "DocVQA": 93.1, "BLINK": 55.7, "InfoVQA": 76.4, "MMMU": 64.3,
+    "LLAVA": 82.6, "ChartQAPro": 72.1, "MMMLU": 78.5,
+    "CVQA": 61.2, "CC-OCR": 58.3, "JIC": 72.4, "MulIm-VQA": 65.8,
+    "JMMMU": 52.1, "JDocQA": 71.3, "JVB-ItW": 78.9, "VG-VQA": 74.2,
+    "Heron": 69.5, "MECHA": 54.7,
+  }),
+  makeEntry("OpenGVLab/InternVL3-78B", "InternVL3-78B", {
+    "OK-VQA": 66.1, "TextVQA": 82.3, "AI2D": 86.7, "ChartQA": 84.5,
+    "DocVQA": 91.4, "BLINK": 53.2, "InfoVQA": 74.1, "MMMU": 62.8,
+    "LLAVA": 80.3, "ChartQAPro": 70.5, "MMMLU": 76.2,
+    "CVQA": 59.8, "CC-OCR": 56.1, "JIC": 70.9, "MulIm-VQA": 63.4,
+    "JMMMU": 50.7, "JDocQA": 69.8, "JVB-ItW": 76.5, "VG-VQA": 72.1,
+    "Heron": 67.3, "MECHA": 52.9,
+  }),
+  makeEntry("gpt-4o-2024-11-20", "GPT-4o", {
+    "OK-VQA": 71.2, "TextVQA": 78.9, "AI2D": 85.3, "ChartQA": 82.1,
+    "DocVQA": 89.7, "BLINK": 58.4, "InfoVQA": 72.8, "MMMU": 68.9,
+    "LLAVA": 85.1, "ChartQAPro": 74.3, "MMMLU": 82.1,
+    "CVQA": 55.6, "CC-OCR": 52.4, "JIC": 68.7, "MulIm-VQA": 71.2,
+    "JMMMU": 56.3, "JDocQA": 65.2, "JVB-ItW": 74.1, "VG-VQA": 70.8,
+    "Heron": 63.5, "MECHA": 58.1,
+  }),
+  makeEntry("Qwen/Qwen2.5-VL-32B-Instruct", "Qwen2.5-VL-32B", {
+    "OK-VQA": 64.7, "TextVQA": 80.5, "AI2D": 84.2, "ChartQA": 81.8,
+    "DocVQA": 88.3, "BLINK": 51.9, "InfoVQA": 71.5, "MMMU": 58.6,
+    "LLAVA": 78.4, "ChartQAPro": 67.2, "MMMLU": 73.8,
+    "CVQA": 57.3, "CC-OCR": 54.7, "JIC": 68.1, "MulIm-VQA": 60.5,
+    "JMMMU": 47.8, "JDocQA": 66.9, "JVB-ItW": 73.2, "VG-VQA": 69.4,
+    "Heron": 64.8, "MECHA": 50.3,
+  }),
+  makeEntry("meta-llama/Llama-3.2-90B-Vision-Instruct", "Llama-3.2-90B", {
+    "OK-VQA": 62.5, "TextVQA": 76.8, "AI2D": 80.1, "ChartQA": 78.4,
+    "DocVQA": 84.6, "BLINK": 49.3, "InfoVQA": 68.2, "MMMU": 55.1,
+    "LLAVA": 75.9, "ChartQAPro": 63.4, "MMMLU": 70.2,
+    "CVQA": 53.1, "CC-OCR": 48.6, "JIC": 62.4, "MulIm-VQA": 55.7,
+    "JMMMU": 43.2, "JDocQA": 60.1, "JVB-ItW": 68.5, "VG-VQA": 64.3,
+    "Heron": 58.7, "MECHA": 45.6,
+  }),
+  makeEntry("OpenGVLab/InternVL3-38B", "InternVL3-38B", {
+    "OK-VQA": 61.8, "TextVQA": 78.2, "AI2D": 82.4, "ChartQA": 80.1,
+    "DocVQA": 86.9, "BLINK": 50.5, "InfoVQA": 70.3, "MMMU": 57.2,
+    "LLAVA": 76.8, "ChartQAPro": 65.1, "MMMLU": 72.4,
+    "CVQA": 55.9, "CC-OCR": 52.3, "JIC": 66.7, "MulIm-VQA": 58.9,
+    "JMMMU": 46.1, "JDocQA": 64.5, "JVB-ItW": 71.8, "VG-VQA": 67.2,
+    "Heron": 62.4, "MECHA": 48.7,
+  }),
+  makeEntry("Qwen/Qwen2.5-VL-7B-Instruct", "Qwen2.5-VL-7B", {
+    "OK-VQA": 58.3, "TextVQA": 74.1, "AI2D": 78.6, "ChartQA": 75.3,
+    "DocVQA": 82.1, "BLINK": 46.8, "InfoVQA": 65.4, "MMMU": 51.3,
+    "LLAVA": 72.5, "ChartQAPro": 59.8, "MMMLU": 67.1,
+    "CVQA": 50.2, "CC-OCR": 47.1, "JIC": 61.3, "MulIm-VQA": 53.6,
+    "JMMMU": 40.5, "JDocQA": 58.7, "JVB-ItW": 65.9, "VG-VQA": 61.5,
+    "Heron": 56.2, "MECHA": 42.8,
+  }),
+  makeEntry("OpenGVLab/InternVL3-8B", "InternVL3-8B", {
+    "OK-VQA": 56.7, "TextVQA": 72.3, "AI2D": 76.8, "ChartQA": 73.6,
+    "DocVQA": 80.4, "BLINK": 45.1, "InfoVQA": 63.7, "MMMU": 49.8,
+    "LLAVA": 70.2, "ChartQAPro": 57.4, "MMMLU": 65.3,
+    "CVQA": 48.5, "CC-OCR": 45.3, "JIC": 59.6, "MulIm-VQA": 51.2,
+    "JMMMU": 38.9, "JDocQA": 56.4, "JVB-ItW": 63.7, "VG-VQA": 59.8,
+    "Heron": 54.1, "MECHA": 40.6,
+  }),
+  makeEntry("google/gemma-3-27b-it", "Gemma-3-27B", {
+    "OK-VQA": 55.1, "TextVQA": 70.8, "AI2D": 75.2, "ChartQA": 71.9,
+    "DocVQA": 78.5, "BLINK": 43.7, "InfoVQA": 61.2, "MMMU": 48.1,
+    "LLAVA": 68.4, "ChartQAPro": 55.6, "MMMLU": 63.7,
+    "CVQA": 46.8, "CC-OCR": 43.5, "JIC": 57.2, "MulIm-VQA": 49.4,
+    "JMMMU": 36.7, "JDocQA": 54.1, "JVB-ItW": 61.3, "VG-VQA": 57.5,
+    "Heron": 52.3, "MECHA": 38.9,
+  }),
+  makeEntry("llm-jp/llm-jp-3-vila-14b", "LLM-JP-3-ViLA-14B", {
+    "OK-VQA": 42.3, "TextVQA": 58.6, "AI2D": 62.1, "ChartQA": 55.8,
+    "DocVQA": 64.2, "BLINK": 38.4, "InfoVQA": 48.7, "MMMU": 35.6,
+    "LLAVA": 55.3, "ChartQAPro": 41.2, "MMMLU": 50.4,
+    "CVQA": 52.4, "CC-OCR": 49.8, "JIC": 63.5, "MulIm-VQA": 56.1,
+    "JMMMU": 42.3, "JDocQA": 62.7, "JVB-ItW": 68.4, "VG-VQA": 65.2,
+    "Heron": 61.8, "MECHA": 46.5,
+  }),
+];
+
+// ── Metadata ────────────────────────────────────────────────────
+
+export const LAST_UPDATED = "2026-04-01";


### PR DESCRIPTION
## Summary

- Stripe-inspired leaderboard with sortable columns, model comparison, stats summary
- API integration: fetchScores for real evaluation data with mock fallback
- Live data indicator when FastAPI backend is active
- StatsSummary shows real task/model counts from API

Closes #203

## Test plan

- [x] `pnpm build` passes
- [x] Static pages generated successfully
- [x] Mock data renders correctly in static mode
- [x] API client functions properly typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)