### PR TITLE
feat: Prediction Browser with Claude-inspired editorial UI (#204)

### DIFF
--- a/web/src/app/browser/page.tsx
+++ b/web/src/app/browser/page.tsx
@@ -1,34 +1,314 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { BrowserSelector } from "@/components/browser-selector";
-import { SampleViewer } from "@/components/sample-viewer";
-import { PredictionPanel } from "@/components/prediction-panel";
+import { SampleViewer, type SampleData } from "@/components/sample-viewer";
+import { PredictionPanel, type PredictionEntry } from "@/components/prediction-panel";
 import { Button } from "@/components/ui/button";
-import { MOCK_SAMPLES, TASKS, MODELS } from "@/lib/mock-predictions";
+import {
+  MOCK_SAMPLES,
+  TASKS as MOCK_TASKS,
+  MODELS as MOCK_MODELS,
+} from "@/lib/mock-predictions";
+import {
+  fetchTasks,
+  fetchModels,
+  fetchPredictions,
+  fetchResults,
+  type ApiTask,
+  type ApiPrediction,
+  type ApiResult,
+} from "@/lib/api";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Deterministic placeholder color from a string. */
+function placeholderColorFor(id: string): string {
+  const palette = ["#d4c5a9", "#b8c5d4", "#c5d4b8", "#d4b8c5", "#c5b8d4"];
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+  return palette[Math.abs(hash) % palette.length];
+}
+
+/** Derive the per-sample score from a prediction record.
+ *
+ * The API stores a score under a key matching the task_id (e.g. "jmmmu": 1).
+ * If the task-specific key is missing, try comparing text vs answer.
+ */
+function extractScore(pred: ApiPrediction, taskId: string): number {
+  if (taskId in pred) {
+    const v = pred[taskId];
+    return typeof v === "number" ? v : -1;
+  }
+  // Fallback: exact match comparison
+  if (pred.text && pred.answer) {
+    return pred.text.trim() === pred.answer.trim() ? 1 : 0;
+  }
+  return -1;
+}
+
+/** Short display name from a model id like "Qwen/Qwen2.5-VL-3B-Instruct". */
+function modelDisplayName(modelId: string): string {
+  return modelId.split("/").pop() ?? modelId;
+}
+
+// ── Types for internal state ─────────────────────────────────────
+
+interface TaskOption {
+  id: string;
+  name: string;
+  sampleCount?: number;
+}
+
+interface ModelOption {
+  id: string;
+  name: string;
+}
+
+// ── Page component ───────────────────────────────────────────────
+
 export default function BrowserPage() {
-  const [selectedTask, setSelectedTask] = useState(TASKS[0].id);
-  const [selectedModels, setSelectedModels] = useState([
-    MODELS[0].id,
-    MODELS[1].id,
+  // Data sources
+  const [tasks, setTasks] = useState<TaskOption[]>(
+    MOCK_TASKS.map((t) => ({ id: t.id, name: t.name, sampleCount: t.sampleCount })),
+  );
+  const [models, setModels] = useState<ModelOption[]>(
+    MOCK_MODELS.map((m) => ({ id: m.id, name: m.name })),
+  );
+  const [usingMock, setUsingMock] = useState(true);
+
+  // Available task/model combos discovered from the result dir
+  const [availableCombos, setAvailableCombos] = useState<
+    Map<string, Set<string>>
+  >(new Map());
+
+  // Selection
+  const [selectedTask, setSelectedTask] = useState(MOCK_TASKS[0].id);
+  const [selectedModels, setSelectedModels] = useState<string[]>([
+    MOCK_MODELS[0].id,
+    MOCK_MODELS[1].id,
   ]);
+
+  // Per-model predictions for the current task
+  // Map from modelId -> array of predictions
+  const [predictionsByModel, setPredictionsByModel] = useState<
+    Map<string, ApiPrediction[]>
+  >(new Map());
+  const [totalByModel, setTotalByModel] = useState<Map<string, number>>(
+    new Map(),
+  );
+  const [predictionsLoading, setPredictionsLoading] = useState(false);
+
+  // Navigation
   const [sampleIndex, setSampleIndex] = useState(0);
 
-  const samples = MOCK_SAMPLES;
-  const currentSample = samples[sampleIndex];
-  const totalSamples = samples.length;
+  // ── Boot: fetch real tasks/models from API ──────────────────────
+  useEffect(() => {
+    let cancelled = false;
 
-  const task = TASKS.find((t) => t.id === selectedTask);
+    async function boot() {
+      try {
+        const [apiTasks, apiModels, apiResults] = await Promise.all([
+          fetchTasks(),
+          fetchModels(),
+          fetchResults(),
+        ]);
+        if (cancelled) return;
+
+        // Build available combos
+        const combos = new Map<string, Set<string>>();
+        apiResults.forEach((r: ApiResult) => {
+          if (!combos.has(r.task_id)) combos.set(r.task_id, new Set());
+          combos.get(r.task_id)!.add(r.model_id);
+        });
+        setAvailableCombos(combos);
+
+        // Use API tasks, but only those that have results
+        const apiTaskOptions: TaskOption[] = apiTasks.map((t: ApiTask) => ({
+          id: t.task_id,
+          name: t.display_name,
+        }));
+        // Also add tasks from results that might not be in metadata
+        const knownIds = new Set(apiTaskOptions.map((t) => t.id));
+        for (const tid of combos.keys()) {
+          if (!knownIds.has(tid)) {
+            apiTaskOptions.push({ id: tid, name: tid });
+          }
+        }
+
+        if (apiTaskOptions.length > 0) {
+          setTasks(apiTaskOptions);
+        }
+
+        // Use all unique models from results
+        const allModelIds = new Set<string>();
+        apiModels.forEach((m: string) => allModelIds.add(m));
+        apiResults.forEach((r: ApiResult) => allModelIds.add(r.model_id));
+        const modelOptions: ModelOption[] = Array.from(allModelIds).map(
+          (id) => ({ id, name: modelDisplayName(id) }),
+        );
+        if (modelOptions.length > 0) {
+          setModels(modelOptions);
+        }
+
+        // Select first available task and its models
+        const firstTask = apiTaskOptions[0]?.id;
+        if (firstTask) {
+          setSelectedTask(firstTask);
+          const taskModels = combos.get(firstTask);
+          if (taskModels && taskModels.size > 0) {
+            const modelArr = Array.from(taskModels);
+            setSelectedModels(modelArr.slice(0, 2));
+          }
+        }
+
+        setUsingMock(false);
+      } catch {
+        // API unreachable — keep mock data
+        setUsingMock(true);
+      }
+    }
+
+    boot();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ── Fetch predictions when task or models change ────────────────
+  const loadPredictions = useCallback(
+    async (taskId: string, modelIds: string[]) => {
+      if (usingMock) return;
+
+      setPredictionsLoading(true);
+      const newPreds = new Map<string, ApiPrediction[]>();
+      const newTotals = new Map<string, number>();
+
+      await Promise.all(
+        modelIds.map(async (modelId) => {
+          try {
+            const resp = await fetchPredictions(taskId, modelId, 0, 200);
+            newPreds.set(modelId, resp.predictions);
+            newTotals.set(modelId, resp.total);
+          } catch {
+            // Model may not have predictions for this task
+          }
+        }),
+      );
+
+      setPredictionsByModel(newPreds);
+      setTotalByModel(newTotals);
+      setPredictionsLoading(false);
+    },
+    [usingMock],
+  );
+
+  useEffect(() => {
+    if (!usingMock && selectedModels.length > 0) {
+      loadPredictions(selectedTask, selectedModels);
+    }
+  }, [selectedTask, selectedModels, usingMock, loadPredictions]);
+
+  // ── Compute the current sample and predictions ──────────────────
+
+  // Determine total sample count (max across loaded models)
+  let totalSamples: number;
+  let currentSample: SampleData | null = null;
+  let currentPredictions: PredictionEntry[] = [];
+
+  if (usingMock) {
+    // Mock path
+    totalSamples = MOCK_SAMPLES.length;
+    const mockSample = MOCK_SAMPLES[sampleIndex];
+    if (mockSample) {
+      currentSample = {
+        id: mockSample.id,
+        imageUrl: mockSample.imageUrl,
+        placeholderColor: mockSample.placeholderColor,
+        question: mockSample.question,
+        groundTruth: mockSample.groundTruth,
+      };
+      currentPredictions = mockSample.predictions.map((p) => ({
+        modelId: p.modelId,
+        modelName: p.modelName,
+        prediction: p.prediction,
+        score: p.score,
+      }));
+    }
+  } else {
+    // Real data path
+    totalSamples = Math.max(
+      0,
+      ...Array.from(totalByModel.values()),
+    );
+
+    // Build sample from the first model that has data at this index
+    for (const [modelId, preds] of predictionsByModel.entries()) {
+      const pred = preds[sampleIndex];
+      if (pred && !currentSample) {
+        currentSample = {
+          id: pred.question_id ?? `sample-${sampleIndex}`,
+          imageUrl: null,
+          placeholderColor: placeholderColorFor(
+            pred.question_id ?? `${sampleIndex}`,
+          ),
+          question: pred.input_text ?? "",
+          groundTruth: pred.answer ?? "",
+        };
+      }
+      if (pred) {
+        currentPredictions.push({
+          modelId,
+          modelName: modelDisplayName(modelId),
+          prediction: pred.text ?? "",
+          score: extractScore(pred, selectedTask),
+        });
+      }
+    }
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────
 
   const goToPrevious = () => {
-    setSampleIndex((prev) => (prev > 0 ? prev - 1 : totalSamples - 1));
+    setSampleIndex((prev) =>
+      totalSamples > 0
+        ? prev > 0
+          ? prev - 1
+          : totalSamples - 1
+        : 0,
+    );
   };
 
   const goToNext = () => {
-    setSampleIndex((prev) => (prev < totalSamples - 1 ? prev + 1 : 0));
+    setSampleIndex((prev) =>
+      totalSamples > 0
+        ? prev < totalSamples - 1
+          ? prev + 1
+          : 0
+        : 0,
+    );
   };
+
+  const handleTaskChange = (taskId: string) => {
+    setSelectedTask(taskId);
+    setSampleIndex(0);
+    setPredictionsByModel(new Map());
+    setTotalByModel(new Map());
+
+    // Auto-select available models for this task
+    if (!usingMock) {
+      const taskModels = availableCombos.get(taskId);
+      if (taskModels && taskModels.size > 0) {
+        const arr = Array.from(taskModels);
+        setSelectedModels(arr.slice(0, 2));
+      }
+    }
+  };
+
+  const task = tasks.find((t) => t.id === selectedTask);
 
   return (
     <div
@@ -48,18 +328,25 @@ export default function BrowserPage() {
             Browse individual model predictions and compare ground-truth
             answers across tasks.
           </p>
+          {usingMock && (
+            <p
+              className="mt-1 text-xs italic"
+              style={{ color: "#87867f" }}
+            >
+              API unavailable — showing mock data.
+            </p>
+          )}
         </div>
 
         {/* Selector bar */}
         <div className="mb-6">
           <BrowserSelector
             selectedTask={selectedTask}
-            onTaskChange={(taskId) => {
-              setSelectedTask(taskId);
-              setSampleIndex(0);
-            }}
+            onTaskChange={handleTaskChange}
             selectedModels={selectedModels}
             onModelsChange={setSelectedModels}
+            tasks={tasks}
+            models={models}
           />
         </div>
 
@@ -73,7 +360,9 @@ export default function BrowserPage() {
               {task.name}
             </span>
             <span className="text-xs" style={{ color: "#87867f" }}>
-              {task.sampleCount} samples in dataset
+              {totalSamples > 0
+                ? `${totalSamples} samples in dataset`
+                : "No samples loaded"}
             </span>
           </div>
         )}
@@ -88,41 +377,56 @@ export default function BrowserPage() {
             {/* Prediction panel */}
             <div className="mb-6">
               <PredictionPanel
-                predictions={currentSample.predictions}
+                predictions={currentPredictions}
                 selectedModels={selectedModels}
+                loading={predictionsLoading}
               />
             </div>
           </>
         )}
 
+        {/* Empty state when no sample */}
+        {!currentSample && !predictionsLoading && (
+          <div
+            className="mb-6 flex items-center justify-center rounded-xl border py-16"
+            style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}
+          >
+            <span className="text-sm" style={{ color: "#87867f" }}>
+              Select a task and model to browse predictions.
+            </span>
+          </div>
+        )}
+
         {/* Navigation */}
-        <div className="flex items-center justify-center gap-4">
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={goToPrevious}
-            style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
-          >
-            <ChevronLeft className="size-4" />
-          </Button>
+        {totalSamples > 0 && (
+          <div className="flex items-center justify-center gap-4">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToPrevious}
+              style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
 
-          <span
-            className="min-w-[80px] text-center text-sm font-medium tabular-nums"
-            style={{ color: "#141413" }}
-          >
-            {sampleIndex + 1}{" "}
-            <span style={{ color: "#87867f" }}>/ {totalSamples}</span>
-          </span>
+            <span
+              className="min-w-[80px] text-center text-sm font-medium tabular-nums"
+              style={{ color: "#141413" }}
+            >
+              {sampleIndex + 1}{" "}
+              <span style={{ color: "#87867f" }}>/ {totalSamples}</span>
+            </span>
 
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={goToNext}
-            style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
-          >
-            <ChevronRight className="size-4" />
-          </Button>
-        </div>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goToNext}
+              style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/app/browser/page.tsx
+++ b/web/src/app/browser/page.tsx
@@ -1,16 +1,128 @@
-export default function BrowserPage() {
-  return (
-    <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold tracking-tight">Prediction Browser</h1>
-      <p className="mt-2 text-muted-foreground">
-        Browse individual model predictions and ground-truth comparisons.
-      </p>
+"use client";
 
-      <div className="mt-8 rounded-lg border bg-card p-6 text-card-foreground">
-        <p className="text-sm text-muted-foreground">
-          Prediction browser coming soon. This page will let you inspect
-          per-sample inputs, model outputs, and scoring details.
-        </p>
+import { useState } from "react";
+import { BrowserSelector } from "@/components/browser-selector";
+import { SampleViewer } from "@/components/sample-viewer";
+import { PredictionPanel } from "@/components/prediction-panel";
+import { Button } from "@/components/ui/button";
+import { MOCK_SAMPLES, TASKS, MODELS } from "@/lib/mock-predictions";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export default function BrowserPage() {
+  const [selectedTask, setSelectedTask] = useState(TASKS[0].id);
+  const [selectedModels, setSelectedModels] = useState([
+    MODELS[0].id,
+    MODELS[1].id,
+  ]);
+  const [sampleIndex, setSampleIndex] = useState(0);
+
+  const samples = MOCK_SAMPLES;
+  const currentSample = samples[sampleIndex];
+  const totalSamples = samples.length;
+
+  const task = TASKS.find((t) => t.id === selectedTask);
+
+  const goToPrevious = () => {
+    setSampleIndex((prev) => (prev > 0 ? prev - 1 : totalSamples - 1));
+  };
+
+  const goToNext = () => {
+    setSampleIndex((prev) => (prev < totalSamples - 1 ? prev + 1 : 0));
+  };
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ backgroundColor: "#f5f4ed" }}
+    >
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Page header */}
+        <div className="mb-6">
+          <h1
+            className="text-3xl font-bold tracking-tight"
+            style={{ color: "#141413" }}
+          >
+            Prediction Browser
+          </h1>
+          <p className="mt-1 text-sm" style={{ color: "#5e5d59" }}>
+            Browse individual model predictions and compare ground-truth
+            answers across tasks.
+          </p>
+        </div>
+
+        {/* Selector bar */}
+        <div className="mb-6">
+          <BrowserSelector
+            selectedTask={selectedTask}
+            onTaskChange={(taskId) => {
+              setSelectedTask(taskId);
+              setSampleIndex(0);
+            }}
+            selectedModels={selectedModels}
+            onModelsChange={setSelectedModels}
+          />
+        </div>
+
+        {/* Task info */}
+        {task && (
+          <div className="mb-4 flex items-center gap-2">
+            <span
+              className="rounded-md px-2 py-0.5 text-xs font-medium"
+              style={{ backgroundColor: "#e8e6dc", color: "#5e5d59" }}
+            >
+              {task.name}
+            </span>
+            <span className="text-xs" style={{ color: "#87867f" }}>
+              {task.sampleCount} samples in dataset
+            </span>
+          </div>
+        )}
+
+        {/* Sample viewer */}
+        {currentSample && (
+          <>
+            <div className="mb-6">
+              <SampleViewer sample={currentSample} />
+            </div>
+
+            {/* Prediction panel */}
+            <div className="mb-6">
+              <PredictionPanel
+                predictions={currentSample.predictions}
+                selectedModels={selectedModels}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Navigation */}
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={goToPrevious}
+            style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+
+          <span
+            className="min-w-[80px] text-center text-sm font-medium tabular-nums"
+            style={{ color: "#141413" }}
+          >
+            {sampleIndex + 1}{" "}
+            <span style={{ color: "#87867f" }}>/ {totalSamples}</span>
+          </span>
+
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={goToNext}
+            style={{ borderColor: "#e8e6dc", color: "#5e5d59" }}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/browser-selector.tsx
+++ b/web/src/components/browser-selector.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TASKS, MODELS } from "@/lib/mock-predictions";
+import { cn } from "@/lib/utils";
+
+interface BrowserSelectorProps {
+  selectedTask: string;
+  onTaskChange: (taskId: string) => void;
+  selectedModels: string[];
+  onModelsChange: (modelIds: string[]) => void;
+}
+
+export function BrowserSelector({
+  selectedTask,
+  onTaskChange,
+  selectedModels,
+  onModelsChange,
+}: BrowserSelectorProps) {
+  const toggleModel = (modelId: string) => {
+    if (selectedModels.includes(modelId)) {
+      // Don't allow deselecting the last model
+      if (selectedModels.length > 1) {
+        onModelsChange(selectedModels.filter((id) => id !== modelId));
+      }
+    } else {
+      onModelsChange([...selectedModels, modelId]);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border p-4" style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+        {/* Task selector */}
+        <div className="flex items-center gap-2">
+          <label
+            className="text-sm font-medium whitespace-nowrap"
+            style={{ color: "#5e5d59" }}
+          >
+            Task
+          </label>
+          <Select value={selectedTask} onValueChange={(value) => { if (value) onTaskChange(value); }}>
+            <SelectTrigger
+              className="min-w-[180px]"
+              style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TASKS.map((task) => (
+                <SelectItem key={task.id} value={task.id}>
+                  {task.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Model multi-select */}
+        <div className="flex items-center gap-2">
+          <label
+            className="text-sm font-medium whitespace-nowrap"
+            style={{ color: "#5e5d59" }}
+          >
+            Models
+          </label>
+          <div className="flex flex-wrap gap-1.5">
+            {MODELS.map((model) => {
+              const isSelected = selectedModels.includes(model.id);
+              return (
+                <button
+                  key={model.id}
+                  type="button"
+                  onClick={() => toggleModel(model.id)}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-medium transition-all",
+                    "border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+                  )}
+                  style={{
+                    borderColor: isSelected ? "#c96442" : "#e8e6dc",
+                    backgroundColor: isSelected ? "#c96442" : "#faf9f5",
+                    color: isSelected ? "#faf9f5" : "#5e5d59",
+                  }}
+                >
+                  {model.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/browser-selector.tsx
+++ b/web/src/components/browser-selector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   Select,
   SelectContent,
@@ -7,14 +8,27 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { TASKS, MODELS } from "@/lib/mock-predictions";
+import { TASKS as MOCK_TASKS, MODELS as MOCK_MODELS } from "@/lib/mock-predictions";
+import { fetchTasks, fetchModels, type ApiTask } from "@/lib/api";
 import { cn } from "@/lib/utils";
+
+interface TaskOption {
+  id: string;
+  name: string;
+}
+
+interface ModelOption {
+  id: string;
+  name: string;
+}
 
 interface BrowserSelectorProps {
   selectedTask: string;
   onTaskChange: (taskId: string) => void;
   selectedModels: string[];
   onModelsChange: (modelIds: string[]) => void;
+  tasks?: TaskOption[];
+  models?: ModelOption[];
 }
 
 export function BrowserSelector({
@@ -22,7 +36,59 @@ export function BrowserSelector({
   onTaskChange,
   selectedModels,
   onModelsChange,
+  tasks: externalTasks,
+  models: externalModels,
 }: BrowserSelectorProps) {
+  const [tasks, setTasks] = useState<TaskOption[]>(
+    externalTasks ?? MOCK_TASKS.map((t) => ({ id: t.id, name: t.name })),
+  );
+  const [models, setModels] = useState<ModelOption[]>(
+    externalModels ?? MOCK_MODELS.map((m) => ({ id: m.id, name: m.name })),
+  );
+
+  // Fetch real data on mount if external data not provided
+  useEffect(() => {
+    if (externalTasks) return;
+    let cancelled = false;
+    fetchTasks()
+      .then((apiTasks: ApiTask[]) => {
+        if (cancelled) return;
+        setTasks(
+          apiTasks.map((t) => ({
+            id: t.task_id,
+            name: t.display_name,
+          })),
+        );
+      })
+      .catch(() => {
+        // Keep mock data on failure
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [externalTasks]);
+
+  useEffect(() => {
+    if (externalModels) return;
+    let cancelled = false;
+    fetchModels()
+      .then((apiModels: string[]) => {
+        if (cancelled) return;
+        setModels(
+          apiModels.map((id) => ({
+            id,
+            name: id.split("/").pop() ?? id,
+          })),
+        );
+      })
+      .catch(() => {
+        // Keep mock data on failure
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [externalModels]);
+
   const toggleModel = (modelId: string) => {
     if (selectedModels.includes(modelId)) {
       // Don't allow deselecting the last model
@@ -53,7 +119,7 @@ export function BrowserSelector({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {TASKS.map((task) => (
+              {tasks.map((task) => (
                 <SelectItem key={task.id} value={task.id}>
                   {task.name}
                 </SelectItem>
@@ -71,7 +137,7 @@ export function BrowserSelector({
             Models
           </label>
           <div className="flex flex-wrap gap-1.5">
-            {MODELS.map((model) => {
+            {models.map((model) => {
               const isSelected = selectedModels.includes(model.id);
               return (
                 <button

--- a/web/src/components/prediction-panel.tsx
+++ b/web/src/components/prediction-panel.tsx
@@ -1,20 +1,56 @@
 "use client";
 
-import type { ModelPrediction } from "@/lib/mock-predictions";
 import { cn } from "@/lib/utils";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
+
+/** Unified prediction shape for display. */
+export interface PredictionEntry {
+  modelId: string;
+  modelName: string;
+  prediction: string;
+  score: number; // 1 = correct, 0 = incorrect, -1 = unknown
+}
 
 interface PredictionPanelProps {
-  predictions: ModelPrediction[];
+  predictions: PredictionEntry[];
   selectedModels: string[];
+  loading?: boolean;
 }
 
 export function PredictionPanel({
   predictions,
   selectedModels,
+  loading,
 }: PredictionPanelProps) {
   const filtered = predictions.filter((p) => selectedModels.includes(p.modelId));
   const isComparison = filtered.length > 1;
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-xl border py-12"
+        style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}
+      >
+        <Loader2 className="size-5 animate-spin" style={{ color: "#c96442" }} />
+        <span className="ml-2 text-sm" style={{ color: "#5e5d59" }}>
+          Loading predictions...
+        </span>
+      </div>
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-xl border py-12"
+        style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}
+      >
+        <span className="text-sm" style={{ color: "#87867f" }}>
+          No predictions available for the selected models.
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -58,13 +94,20 @@ export function PredictionPanel({
                   <CheckCircle2 className="size-3" />
                   Correct
                 </span>
-              ) : (
+              ) : pred.score === 0 ? (
                 <span
                   className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
                   style={{ backgroundColor: "#fce8e0", color: "#c96442" }}
                 >
                   <XCircle className="size-3" />
                   Incorrect
+                </span>
+              ) : (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+                  style={{ backgroundColor: "#e8e6dc", color: "#87867f" }}
+                >
+                  N/A
                 </span>
               )}
             </div>

--- a/web/src/components/prediction-panel.tsx
+++ b/web/src/components/prediction-panel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { ModelPrediction } from "@/lib/mock-predictions";
+import { cn } from "@/lib/utils";
+import { CheckCircle2, XCircle } from "lucide-react";
+
+interface PredictionPanelProps {
+  predictions: ModelPrediction[];
+  selectedModels: string[];
+}
+
+export function PredictionPanel({
+  predictions,
+  selectedModels,
+}: PredictionPanelProps) {
+  const filtered = predictions.filter((p) => selectedModels.includes(p.modelId));
+  const isComparison = filtered.length > 1;
+
+  return (
+    <div
+      className="rounded-xl border"
+      style={{ borderColor: "#e8e6dc", backgroundColor: "#faf9f5" }}
+    >
+      <div className="px-4 py-3" style={{ borderBottom: "1px solid #e8e6dc" }}>
+        <h3
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "#87867f" }}
+        >
+          {isComparison ? "Model Comparison" : "Prediction"}
+        </h3>
+      </div>
+
+      <div
+        className={cn(
+          "divide-y",
+          isComparison ? "grid sm:grid-cols-2 sm:divide-y-0 sm:divide-x" : ""
+        )}
+        style={
+          isComparison
+            ? { ["--tw-divide-color" as string]: "#e8e6dc" }
+            : { ["--tw-divide-color" as string]: "#e8e6dc" }
+        }
+      >
+        {filtered.map((pred) => (
+          <div key={pred.modelId} className="px-4 py-3">
+            <div className="mb-1.5 flex items-center gap-2">
+              <span
+                className="text-sm font-semibold"
+                style={{ color: "#141413" }}
+              >
+                {pred.modelName}
+              </span>
+              {pred.score === 1 ? (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+                  style={{ backgroundColor: "#e6f4e6", color: "#2d7a2d" }}
+                >
+                  <CheckCircle2 className="size-3" />
+                  Correct
+                </span>
+              ) : (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+                  style={{ backgroundColor: "#fce8e0", color: "#c96442" }}
+                >
+                  <XCircle className="size-3" />
+                  Incorrect
+                </span>
+              )}
+            </div>
+            <p
+              className="text-sm leading-relaxed"
+              style={{
+                fontFamily: "Georgia, 'Times New Roman', serif",
+                color: "#5e5d59",
+              }}
+            >
+              {pred.prediction}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/sample-viewer.tsx
+++ b/web/src/components/sample-viewer.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import type { Sample } from "@/lib/mock-predictions";
 import { ImageIcon } from "lucide-react";
 
+/** Unified sample shape used across mock and real data. */
+export interface SampleData {
+  id: string;
+  imageUrl: string | null;
+  placeholderColor: string;
+  question: string;
+  groundTruth: string;
+}
+
 interface SampleViewerProps {
-  sample: Sample;
+  sample: SampleData;
 }
 
 export function SampleViewer({ sample }: SampleViewerProps) {

--- a/web/src/components/sample-viewer.tsx
+++ b/web/src/components/sample-viewer.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { Sample } from "@/lib/mock-predictions";
+import { ImageIcon } from "lucide-react";
+
+interface SampleViewerProps {
+  sample: Sample;
+}
+
+export function SampleViewer({ sample }: SampleViewerProps) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      {/* Image area */}
+      <div
+        className="flex aspect-[4/3] items-center justify-center overflow-hidden rounded-xl border"
+        style={{
+          borderColor: "#e8e6dc",
+          backgroundColor: sample.imageUrl ? undefined : sample.placeholderColor,
+        }}
+      >
+        {sample.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={sample.imageUrl}
+            alt="Sample image"
+            className="h-full w-full object-contain"
+          />
+        ) : (
+          <div className="flex flex-col items-center gap-3 text-center">
+            <ImageIcon
+              className="size-12 opacity-40"
+              style={{ color: "#5e5d59" }}
+            />
+            <span
+              className="text-sm font-medium opacity-60"
+              style={{ color: "#5e5d59" }}
+            >
+              {sample.id}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Question + Ground truth */}
+      <div className="flex flex-col gap-4">
+        <div>
+          <h3
+            className="mb-2 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "#87867f" }}
+          >
+            Question
+          </h3>
+          <p
+            className="text-base leading-relaxed"
+            style={{
+              fontFamily: "Georgia, 'Times New Roman', serif",
+              color: "#141413",
+            }}
+          >
+            {sample.question}
+          </p>
+        </div>
+
+        <div
+          className="rounded-lg p-4"
+          style={{ backgroundColor: "#141413" }}
+        >
+          <h3
+            className="mb-1.5 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "#87867f" }}
+          >
+            Ground Truth
+          </h3>
+          <p
+            className="text-sm font-medium leading-relaxed"
+            style={{
+              fontFamily: "Georgia, 'Times New Roman', serif",
+              color: "#faf9f5",
+            }}
+          >
+            {sample.groundTruth}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/web/src/components/ui/separator.tsx
+++ b/web/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -67,3 +67,41 @@ export async function fetchAllScores(): Promise<Record<string, ApiScoreEntry[]>>
   }
   return scores;
 }
+
+// ── Prediction browsing ──────────────────────────────────────────
+
+export interface ApiPrediction {
+  question_id: string;
+  text: string; // model's prediction
+  answer: string; // ground truth
+  input_text: string; // the question / prompt
+  [key: string]: unknown; // task-specific score fields (e.g. "jmmmu": 1)
+}
+
+export interface ApiPredictionsResponse {
+  task_id: string;
+  model_id: string;
+  total: number;
+  offset: number;
+  limit: number;
+  predictions: ApiPrediction[];
+}
+
+export async function fetchPredictions(
+  taskId: string,
+  modelId: string,
+  offset = 0,
+  limit = 10,
+): Promise<ApiPredictionsResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/predictions/${taskId}/${encodeURIComponent(modelId)}?offset=${offset}&limit=${limit}`,
+  );
+  if (!res.ok)
+    throw new Error(`Failed to fetch predictions: ${res.status}`);
+  return res.json();
+}
+
+/** Discover which task/model combinations have results. */
+export async function fetchAvailableResults(): Promise<ApiResult[]> {
+  return fetchResults();
+}

--- a/web/src/lib/mock-predictions.ts
+++ b/web/src/lib/mock-predictions.ts
@@ -1,0 +1,118 @@
+/** Mock data for the Prediction Browser. */
+
+export interface ModelPrediction {
+  modelId: string;
+  modelName: string;
+  prediction: string;
+  score: number; // 1 = correct, 0 = incorrect
+}
+
+export interface Sample {
+  id: string;
+  /** Placeholder image URL or null for a colored placeholder */
+  imageUrl: string | null;
+  /** Hex color for the placeholder when imageUrl is null */
+  placeholderColor: string;
+  question: string;
+  groundTruth: string;
+  predictions: ModelPrediction[];
+}
+
+export interface Task {
+  id: string;
+  name: string;
+  sampleCount: number;
+}
+
+export const TASKS: Task[] = [
+  { id: "jmmmu", name: "JMMMU", sampleCount: 150 },
+  { id: "japanese-heron-bench", name: "Japanese Heron Bench", sampleCount: 85 },
+  { id: "jdocqa", name: "JDocQA", sampleCount: 200 },
+  { id: "mmmu", name: "MMMU", sampleCount: 300 },
+];
+
+export const MODELS = [
+  { id: "qwen2.5-vl-72b", name: "Qwen2.5-VL-72B" },
+  { id: "internvl3-78b", name: "InternVL3-78B" },
+  { id: "gpt-4o", name: "GPT-4o" },
+  { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash" },
+  { id: "llava-next-72b", name: "LLaVA-NeXT-72B" },
+];
+
+export const MOCK_SAMPLES: Sample[] = [
+  {
+    id: "jmmmu-001",
+    imageUrl: null,
+    placeholderColor: "#d4c5a9",
+    question:
+      "この回路図において、抵抗R1とR2が直列に接続されている場合、合成抵抗はいくらになりますか？R1=10\u03A9, R2=20\u03A9とします。",
+    groundTruth: "30\u03A9",
+    predictions: [
+      { modelId: "qwen2.5-vl-72b", modelName: "Qwen2.5-VL-72B", prediction: "30\u03A9", score: 1 },
+      { modelId: "internvl3-78b", modelName: "InternVL3-78B", prediction: "30\u03A9", score: 1 },
+      { modelId: "gpt-4o", modelName: "GPT-4o", prediction: "30\u03A9", score: 1 },
+      { modelId: "gemini-2.0-flash", modelName: "Gemini 2.0 Flash", prediction: "200\u03A9", score: 0 },
+      { modelId: "llava-next-72b", modelName: "LLaVA-NeXT-72B", prediction: "30\u03A9", score: 1 },
+    ],
+  },
+  {
+    id: "jmmmu-002",
+    imageUrl: null,
+    placeholderColor: "#b8c5d4",
+    question:
+      "この地図に示されている都市の名前は何ですか？また、その都市が属する都道府県名も答えてください。",
+    groundTruth: "京都市、京都府",
+    predictions: [
+      { modelId: "qwen2.5-vl-72b", modelName: "Qwen2.5-VL-72B", prediction: "京都市、京都府", score: 1 },
+      { modelId: "internvl3-78b", modelName: "InternVL3-78B", prediction: "大阪市、大阪府", score: 0 },
+      { modelId: "gpt-4o", modelName: "GPT-4o", prediction: "京都市、京都府", score: 1 },
+      { modelId: "gemini-2.0-flash", modelName: "Gemini 2.0 Flash", prediction: "京都市、京都府", score: 1 },
+      { modelId: "llava-next-72b", modelName: "LLaVA-NeXT-72B", prediction: "奈良市、奈良県", score: 0 },
+    ],
+  },
+  {
+    id: "jmmmu-003",
+    imageUrl: null,
+    placeholderColor: "#c5d4b8",
+    question:
+      "このグラフから読み取れる2023年の売上高はいくらですか？単位は億円で答えてください。",
+    groundTruth: "42億円",
+    predictions: [
+      { modelId: "qwen2.5-vl-72b", modelName: "Qwen2.5-VL-72B", prediction: "42億円", score: 1 },
+      { modelId: "internvl3-78b", modelName: "InternVL3-78B", prediction: "45億円", score: 0 },
+      { modelId: "gpt-4o", modelName: "GPT-4o", prediction: "42億円", score: 1 },
+      { modelId: "gemini-2.0-flash", modelName: "Gemini 2.0 Flash", prediction: "42億円", score: 1 },
+      { modelId: "llava-next-72b", modelName: "LLaVA-NeXT-72B", prediction: "40億円", score: 0 },
+    ],
+  },
+  {
+    id: "jmmmu-004",
+    imageUrl: null,
+    placeholderColor: "#d4b8c5",
+    question:
+      "この化学構造式が表す化合物の名称をIUPAC命名法で答えてください。",
+    groundTruth: "2-メチルプロパン-1-オール",
+    predictions: [
+      { modelId: "qwen2.5-vl-72b", modelName: "Qwen2.5-VL-72B", prediction: "2-メチルプロパン-1-オール", score: 1 },
+      { modelId: "internvl3-78b", modelName: "InternVL3-78B", prediction: "イソブタノール", score: 0 },
+      { modelId: "gpt-4o", modelName: "GPT-4o", prediction: "2-メチルプロパン-1-オール", score: 1 },
+      { modelId: "gemini-2.0-flash", modelName: "Gemini 2.0 Flash", prediction: "2-methylpropan-1-ol", score: 0 },
+      { modelId: "llava-next-72b", modelName: "LLaVA-NeXT-72B", prediction: "2-メチルプロパン-1-オール", score: 1 },
+    ],
+  },
+  {
+    id: "jmmmu-005",
+    imageUrl: null,
+    placeholderColor: "#c5b8d4",
+    question:
+      "この絵画の作者と作品名を答えてください。日本語で回答すること。",
+    groundTruth: "葛飾北斎「富嶽三十六景 神奈川沖浪裏」",
+    predictions: [
+      { modelId: "qwen2.5-vl-72b", modelName: "Qwen2.5-VL-72B", prediction: "葛飾北斎「富嶽三十六景 神奈川沖浪裏」", score: 1 },
+      { modelId: "internvl3-78b", modelName: "InternVL3-78B", prediction: "葛飾北斎「富嶽三十六景 神奈川沖浪裏」", score: 1 },
+      { modelId: "gpt-4o", modelName: "GPT-4o", prediction: "葛飾北斎「富嶽三十六景 神奈川沖浪裏」", score: 1 },
+      { modelId: "gemini-2.0-flash", modelName: "Gemini 2.0 Flash", prediction: "葛飾北斎「神奈川沖浪裏」", score: 0 },
+      { modelId: "llava-next-72b", modelName: "LLaVA-NeXT-72B", prediction: "歌川広重「東海道五十三次」", score: 0 },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary

- Claude-inspired warm editorial design (parchment, Georgia serif, terracotta accents)
- API integration: fetchPredictions with pagination, multi-model comparison
- Auto-select models from available evaluation results
- Components: BrowserSelector, SampleViewer, PredictionPanel
- Dual-mode: static with mock data, live with FastAPI backend

Closes #204

## Test plan

- [x] `pnpm build` passes (all 7 pages generated)
- [x] Mock data renders correctly in static mode
- [x] API client functions properly typed
- [x] Multi-model comparison UI functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)