### PR TITLE
fix(tsubame): increase tensor_parallel for InternVL3-38B (#225)

### DIFF
--- a/tsubame/config.sh
+++ b/tsubame/config.sh
@@ -170,8 +170,8 @@ declare -a MODEL_LIST=(
     "google/gemma-4-31B-it|gemma4|transformers"
     # "turing-motors/Heron-NVILA-Lite-33B|heron_nvila|transformers"  # 33B: 1GPU では VRAM 不足
     "AIDC-AI/Ovis2-34B|vllm_normal|vllm|2"
-    "OpenGVLab/InternVL3-38B|vllm_normal|vllm|2"
-    "OpenGVLab/InternVL3_5-38B|vllm_normal|vllm|2"
+    "OpenGVLab/InternVL3-38B|vllm_normal|vllm|4"
+    "OpenGVLab/InternVL3_5-38B|vllm_normal|vllm|4"
     # ~72B+ (tp=4)
     "Qwen/Qwen2-VL-72B-Instruct|vllm_normal|vllm|4"
     "Qwen/Qwen2.5-VL-72B-Instruct|vllm_normal|vllm|4"


### PR DESCRIPTION
Refs #225

## 変更概要
- InternVL3-38B / InternVL3_5-38B の tensor_parallel を 2→4 に変更（OOM 解消）
- mathvista タスクを再有効化

## 背景
38B モデルが tp=2 (node_h, 2 GPU) で CUDA OOM していた。H100 1枚 93 GiB に対し、モデルウェイト ~38 GiB/GPU + KV cache + VLM activations で超過。tp=4 (node_f, 4 GPU) にすることで 1 GPU あたり ~19 GiB に分散し、十分な余裕を確保。

## /review 結果

| サブエージェント | 判定 | 詳細 |
|-----------------|------|------|
| アーキテクチャレビュー | ✅ | tp=4 は 72B+ モデルと同カテゴリで妥当 |
| リスクレビュー | ✅ | 正当な修正、リスクなし |
| テストレビュー | ✅ | 設定値変更のみ、テスト不要 |
| Fallbackチェッカー | ✅ | fallback パターンなし |
| 仕様充足チェッカー | ✅ | Issue #225 要件に合致 |
| ロジック検証 | ✅ | 構文・論理的に正しい |
| Best Practice | ✅ | 既存パターンと一貫 |

## テスト結果
設定値変更のみのため自動テスト不要。TSUBAME での再実行で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)